### PR TITLE
Add experimental autoFeed option to GoogleAIStudioCompleter, update tooling

### DIFF
--- a/src/ChatSession.js
+++ b/src/ChatSession.js
@@ -153,7 +153,7 @@ class ChatSession {
     this.messages.push({ role: 'user', content })
     let guidance
     if (message.guidanceText) {
-      guidance = { role: 'assistant', content: message.guidanceText }
+      guidance = { role: 'guidance', content: message.guidanceText }
       this.messages.push(guidance)
       chunkCb?.({ done: false, delta: message.guidanceText, content: message.guidanceText })
     }

--- a/src/CompletionService.js
+++ b/src/CompletionService.js
@@ -86,7 +86,10 @@ class CompletionService {
       tools: functions || undefined,
       tool_choice: functions ? 'auto' : undefined
     }, (chunk) => {
-      if (!chunk) return
+      if (!chunk) {
+        chunkCb?.({ done: true, delta: '' })
+        return
+      }
       const choice = chunk.choices[0]
       if (choice.finish_reason) {
         finishReason = choice.finish_reason

--- a/src/CompletionService.js
+++ b/src/CompletionService.js
@@ -76,7 +76,12 @@ class CompletionService {
     await openai.getStreamingCompletion(this.openaiApiKey, {
       model,
       max_tokens: maxTokens,
-      messages,
+      messages: messages.map((entry) => {
+        const msg = structuredClone(entry)
+        if (msg.role === 'model') msg.role = 'assistant'
+        if (msg.role === 'guidance') msg.role = 'assistant'
+        return msg
+      }),
       stream: true,
       tools: functions || undefined,
       tool_choice: functions ? 'auto' : undefined
@@ -121,6 +126,7 @@ class CompletionService {
       const m = structuredClone(msg)
       if (msg.role === 'assistant') m.role = 'model'
       if (msg.role === 'system') m.role = 'user'
+      if (msg.role === 'guidance') m.role = 'model'
       if (msg.content) {
         delete m.content
         m.parts = [{ text: msg.content }]

--- a/src/GoogleAIStudioCompletionService.js
+++ b/src/GoogleAIStudioCompletionService.js
@@ -17,7 +17,7 @@ class GoogleAIStudioCompletionService {
     studio.stopServer()
   }
 
-  async requestCompletion (model, system, user, chunkCb, options) {
+  async requestCompletion (model, system, user, chunkCb, options = {}) {
     if (!supportedModels.includes(model)) {
       throw new Error(`Model ${model} is not supported`)
     }

--- a/src/GoogleAIStudioCompletionService.js
+++ b/src/GoogleAIStudioCompletionService.js
@@ -18,8 +18,10 @@ class GoogleAIStudioCompletionService {
     }
     const guidance = system?.guidanceText || user?.guidanceText || ''
     if (guidance) chunkCb?.({ done: false, delta: guidance })
-    const mergedPrompt = [system, user].join('\n')
-    const result = await studio.generateCompletion(model, mergedPrompt, chunkCb)
+    const mergedPrompt = [system?.basePrompt || system, user?.basePrompt || user].join('\n')
+    const messages = [{ role: 'user', content: mergedPrompt }]
+    if (guidance) messages.push({ role: 'model', content: guidance })
+    const result = await studio.generateCompletion(model, messages, chunkCb)
     return { text: guidance + result.text }
   }
 

--- a/src/googleAIStudio.js
+++ b/src/googleAIStudio.js
@@ -79,7 +79,6 @@ async function generateCompletion (model, messages, chunkCb, options) {
   // If the user is using streaming, they won't face any delay getting the response
   throttle = await sleep(6000)
   isBusy = false
-  chunkCb?.({ done: true, delta: '\n' })
   return {
     text: response.text
   }
@@ -114,12 +113,10 @@ async function requestChatCompletion (model, messages, chunkCb, options) {
       const content = `<|ASSISTANT|>\n${message.content})`
       guidanceMessage = content
     } else if (message.role === 'user') {
-      // msg += `\n<|USER|>\n${message.content}`
       const content = `<|USER|>\n${message.content}`
       prefixedMessages.push({ role: 'user', content })
     } else if (message.role === 'function') {
       // TODO: log the function name also maybe?
-      // msg += `\n<|FUNCTION_OUTPUT|>\n${message.content})`
       const content = `<|FUNCTION_OUTPUT|>\n${message.content})`
       prefixedMessages.push({ role: 'user', content })
     }

--- a/src/googleAIStudio.js
+++ b/src/googleAIStudio.js
@@ -56,16 +56,16 @@ function stopServer () {
   serverPromise = null
 }
 
-async function generateCompletion (model, prompt, chunkCb, options) {
+async function generateCompletion (model, messages, chunkCb, options) {
   await runServer()
   await throttle
   if (isBusy) {
     throw new Error('Only one request at a time is supported with AI Studio, please wait for the previous request to finish')
   }
-  prompt = prompt.trim() + '\n'
   // console.log('Sending completion request to server', model, prompt)
   isBusy = true
-  serverConnection.emit('completionRequest', { model, prompt, stopSequences: options?.stopSequences })
+  const prompt = messages.map(m => m.content).join('\n')
+  serverConnection.emit('completionRequest', { model, prompt, messages, stopSequences: options?.stopSequences })
   function completionChunk (response) {
     chunkCb?.(response)
   }
@@ -77,7 +77,7 @@ async function generateCompletion (model, prompt, chunkCb, options) {
   serverConnection.off('completionChunk', completionChunk)
   // console.log('Done')
   // If the user is using streaming, they won't face any delay getting the response
-  throttle = await sleep(2000)
+  throttle = await sleep(6000)
   isBusy = false
   chunkCb?.({ done: true, delta: '\n' })
   return {
@@ -90,33 +90,55 @@ const basePrompt = importPromptRaw('./googleAiStudioPrompt.txt')
 async function requestChatCompletion (model, messages, chunkCb, options) {
   const hasSystemMessage = messages.some(m => m.role === 'system')
   const stops = ['<|ASSISTANT|>', '<|USER|>', '<|SYSTEM|>', '<|FUNCTION_OUTPUT|>', '</FUNCTION_CALL>']
-  let msg = loadPrompt(basePrompt, {
+  const msg = loadPrompt(basePrompt, {
     HAS_PROMPT: hasSystemMessage,
     HAS_FUNCTIONS: !!options.functions,
     LIST_OF_FUNCTIONS: options.functions ? encodeYaml(options.functions) : ''
   })
+  const prefixedMessages = [{ role: 'user', content: msg }]
+  let guidanceMessage
   for (let i = 0; i < messages.length; i++) {
     const message = messages[i]
     if (i === 0 && message.role === 'system' && message.content) {
-      msg += '\nYour prompt is as follows:\n'
-      msg += message.content
+      // Modify the first user message (which acts as system prompt)
+      const firstMessage = prefixedMessages[0]
+      firstMessage.content += '\nYour prompt is as follows:\n'
+      firstMessage.content += message.content
     } else if (message.role === 'system') {
       throw new Error('The first message must be a system message')
     }
     if (message.role === 'assistant' || message.role === 'model') {
-      msg += `\n<|ASSISTANT|>\n${message.content}`
+      const content = `<|ASSISTANT|>\n${message.content})`
+      prefixedMessages.push({ role: 'model', content })
+    } else if (message.role === 'guidance') {
+      const content = `<|ASSISTANT|>\n${message.content})`
+      guidanceMessage = content
     } else if (message.role === 'user') {
-      msg += `\n<|USER|>\n${message.content}`
+      // msg += `\n<|USER|>\n${message.content}`
+      const content = `<|USER|>\n${message.content}`
+      prefixedMessages.push({ role: 'user', content })
     } else if (message.role === 'function') {
       // TODO: log the function name also maybe?
-      msg += `\n<|FUNCTION_OUTPUT|>\n${message.content})`
+      // msg += `\n<|FUNCTION_OUTPUT|>\n${message.content})`
+      const content = `<|FUNCTION_OUTPUT|>\n${message.content})`
+      prefixedMessages.push({ role: 'user', content })
     }
   }
-  msg += '\n<|ASSISTANT|>'
+  // We don't actually need all these roles, it just makes things more complicated for the LLM
+  // since it already has a way to distinguish between user and model messages.
+  // So let's just merge them into one user message, and only put in a model message
+  // at the end if the user is specifying some guidance fot the model's response.
+  const finalMessageStr = prefixedMessages.map(m => m.content).join('\n')
+  const finalMessages = [{ role: 'user', content: finalMessageStr }]
+  if (guidanceMessage) {
+    finalMessages.push({ role: 'model', content: guidanceMessage })
+  } else {
+    finalMessages[0].content += '\n<|ASSISTANT|>'
+  }
 
-  debug('Sending chat completion request to server', model, msg)
+  debug('Sending chat completion request to server', model, finalMessages)
 
-  const response = await generateCompletion(model, msg, chunkCb, {
+  const response = await generateCompletion(model, finalMessages, chunkCb, {
     ...options,
     stopSequences: stops.concat(options?.stopSequences || [])
   })

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -23,7 +23,14 @@ declare module 'langxlang' {
     stop(): void
 
     // Request a non-streaming completion from the model.
-    requestCompletion(model: Model, systemPrompt: string, userPrompt: string, chunkCb?: ChunkCb): Promise<{ text: string }>
+    requestCompletion(model: Model, systemPrompt: string, userPrompt: string, chunkCb?: ChunkCb, options?: {
+      autoFeed?: {
+        // Once a line matching stopLine is hit, stop trying to feed the model more input
+        stopLine: string,
+        // The maximum number of rounds to feed the model
+        maxRounds: number,
+      }
+    }): Promise<{ text: string }>
   }
 
   interface Func {

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -61,6 +61,8 @@ declare module 'langxlang' {
     // Either a function that returns true if the file should be included
     // or an array of regexes of which one needs to match for inclusion
     matching?: (fileName: string) => boolean | RegExp[]
+    // An optional list of strings for which if the path starts with one of them, it's excluded, even if it was matched by `extension` or `matching`
+    excludingPrefixes?: string[]
   }
 
   interface Tools {

--- a/src/tools.js
+++ b/src/tools.js
@@ -22,7 +22,7 @@ function createTypeWriterEffectStream (to = process.stdout) {
       to.write('\n')
       clearInterval(interval)
     }
-    remainingToWrite += chunk.delta
+    remainingToWrite += chunk.content || chunk.delta
   }
 }
 

--- a/src/tools/codebase.js
+++ b/src/tools/codebase.js
@@ -27,6 +27,7 @@ function collectFolderFiles (folder, options) {
   // Now collect all the files inside repoPath, like `tree`: [absolute, relative]
   const allFiles = getAllFilesIn(folderFixed)
     .map(f => [f, f.replace(folderFixed, '')])
+  const excluding = options.excludingPrefixes || ['/node_modules', '/.git']
 
   // Now figure out the relevant files
   const relevantFiles = []
@@ -46,6 +47,9 @@ function collectFolderFiles (folder, options) {
       } else {
         throw new Error('options.matching must be a function or an array of regexes or strings')
       }
+    }
+    if (excluding.some(ex => relFile.startsWith(ex))) {
+      continue
     }
     relevantFiles.push([file, relFile])
   }

--- a/src/util.js
+++ b/src/util.js
@@ -1,4 +1,5 @@
 function cleanMessage (msg) {
+  if (!msg) return msg
   // fix systemMessage \r\n to \n
   return msg.replace(/\r\n/g, '\n')
 }

--- a/test/googleaistudio.js
+++ b/test/googleaistudio.js
@@ -29,9 +29,9 @@ async function testCompletionChat () {
   const service = new GoogleAIStudioCompletionService(8095)
   await service.ready
 
-  const result = await service.requestStreamingChat('gemini-1.5-pro', [
-    { role: 'user', content: 'How are you doing today?' }
-  ])
+  const result = await service.requestStreamingChat('gemini-1.5-pro', {
+    messages: [{ role: 'user', content: 'How are you doing today?' }]
+  }, pleasantWriter())
   console.log('Result', result.text)
   service.stop()
 }
@@ -121,6 +121,7 @@ async function repl () {
 
 async function main () {
   await testCompletion()
+  await testCompletionChat()
   await testChatSession()
   await testChatSessionWithFunctions()
 }


### PR DESCRIPTION
Experimental autoFeed to play with Gemini 1.5 Pro's larger context window ; doesn't quite work well since the model gets lazy when it nears its context limit as opposed to generating as much tokens as possible. To do this it may require a new output validator. 

Will either need to wait for better models here or perhaps play with ToT in the meantime.

* Add `excludingPrefixes` to file collection tool to omit unneeded info from output
* Fixes to streaming handling