### PR TITLE
GoogleAIStudio: add option to send requests to HTTP server relay

### DIFF
--- a/src/GoogleAIStudioCompletionService.js
+++ b/src/GoogleAIStudioCompletionService.js
@@ -9,9 +9,14 @@ function checkContainsStopTokenLine (message, token) {
 }
 
 class GoogleAIStudioCompletionService {
-  constructor (serverPort) {
-    this.serverPort = serverPort
-    this.ready = studio.runServer(serverPort)
+  constructor (serverPortOrEndpointData = 8095) {
+    if (typeof serverPortOrEndpointData === 'number') {
+      this.serverPort = serverPortOrEndpointData
+      this.ready = studio.runServer(this.serverPort)
+    } else if (typeof serverPortOrEndpointData === 'object') {
+      this.serverBase = serverPortOrEndpointData
+      this.ready = studio.readyHTTP(this.serverBase)
+    }
   }
 
   stop () {

--- a/src/GoogleAIStudioCompletionService.js
+++ b/src/GoogleAIStudioCompletionService.js
@@ -15,7 +15,10 @@ class GoogleAIStudioCompletionService {
       this.ready = studio.runServer(this.serverPort)
     } else if (typeof serverPortOrEndpointData === 'object') {
       this.serverBase = serverPortOrEndpointData
+      if (!this.serverBase?.baseURL) throw new Error('Invalid configuration for HTTP server endpoint')
       this.ready = studio.readyHTTP(this.serverBase)
+    } else {
+      throw new Error('Invalid arguments')
     }
   }
 

--- a/src/googleAIStudio.js
+++ b/src/googleAIStudio.js
@@ -15,6 +15,7 @@ let serverConnection
 let serverPromise
 let wss
 
+let throttleTime = 6000
 let throttle, isBusy
 
 // 1. Run a local server that a local AI Studio client can connect to
@@ -81,6 +82,8 @@ function readyHTTP ({ baseURL, apiKey }) {
     }
   })
   serverPromise = Promise.resolve()
+  // Lower throttle time for HTTP requests
+  throttleTime = 1000
 }
 
 // This method generates a completion using a local AI Studio websocket server that clients can connect to
@@ -105,7 +108,7 @@ async function generateCompletion (model, messages, chunkCb, options) {
   serverConnection.off('completionChunk', completionChunk)
   // console.log('Done')
   // If the user is using streaming, they won't face any delay getting the response
-  throttle = await sleep(6000)
+  throttle = await sleep(throttleTime)
   isBusy = false
   return {
     text: response.text

--- a/src/googleAIStudio.js
+++ b/src/googleAIStudio.js
@@ -75,7 +75,7 @@ function readyHTTP ({ baseURL, apiKey }) {
       },
       body: JSON.stringify(request)
     }).then(res => res.json())
-    console.log('LXL: Got response from HTTP server', response)
+    debug('LXL: Got response from HTTP server', response)
     if (response.response) {
       serverConnection.emit('completionResponse', response.response)
     }

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -18,8 +18,13 @@ declare module 'langxlang' {
     }): Promise<{ text: string }>
   }
   class GoogleAIStudioCompletionService {
-    // Creates an instance of GoogleAIStudioCompletionService. The port is the port that the server should listen on.
+    // Creates an instance of GoogleAIStudioCompletionService that hosts a WebSocket server at specified port.
+    // AIStudio clients can connect to that port to work with LXL.
+    // The port is the port that the server should listen on.
     constructor(port: number)
+    // Creates an instance that instead makes an HTTP request to a relay server, 
+    // that then forwards the request to an AIStudio client.
+    constructor({ baseURL: string, apiKey: string })
     // Promise that resolves when the server is ready to accept requests.
     ready: Promise<void>
     // Stop the server.

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -124,7 +124,7 @@ declare module 'langxlang' {
     extractCodeblockFromMarkdown(markdownInput: string): { raw: string, lang: string, code: string }[]
     // Wraps the contents by using the specified token character at least 3 times,
     // ensuring that the token is long enough that it's not present in the content
-    wrapContent(content: string, withChar = '```', initialTokenSuffix = ''): string
+    wrapContent(content: string, withChar = '`', initialTokenSuffix = ''): string
   }
 
   const tools: Tools


### PR DESCRIPTION
Allows using a seperate relay server that does HTTP <-> WebSocket server <-> AIStudioClient.