### PR TITLE
Add `stripDiff`, support truncation and binary files in collectFolderFiles and markdown gen, handle corrupt caches

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
   },
   "homepage": "https://github.com/extremeheat/LXL#readme",
   "devDependencies": {
-    "gpt-tokenizer": "^2.1.2",
     "langxlang": "file:.",
     "mocha": "^10.0.0",
     "standard": "^17.0.0"
@@ -41,6 +40,7 @@
     "acorn": "^8.11.3",
     "caller": "^1.1.0",
     "debug": "^4.3.4",
+    "gpt-tokenizer": "^2.1.2",
     "openai": "^4.28.0",
     "ws": "^8.16.0"
   }

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   },
   "homepage": "https://github.com/extremeheat/LXL#readme",
   "devDependencies": {
+    "gpt-tokenizer": "^2.1.2",
     "langxlang": "file:.",
     "mocha": "^10.0.0",
     "standard": "^17.0.0"

--- a/src/caching.js
+++ b/src/caching.js
@@ -30,6 +30,9 @@ async function loadResponseCache () {
   }
   return fs.promises.readFile(lxlResponsePath, 'utf-8').then(data => {
     responseCache = JSON.parse(data)
+  }).catch(() => {
+    fs.writeFileSync(lxlResponsePath, '{}')
+    responseCache = {}
   })
 }
 

--- a/src/googleAIStudio.js
+++ b/src/googleAIStudio.js
@@ -42,6 +42,10 @@ function runServer (port = 8095) {
           serverConnection.emit('completionResponse', data.response)
         } else if (data.type === 'completionChunk') {
           serverConnection.emit('completionChunk', data.response)
+        } else if (data.type === 'error') {
+          serverConnection.emit('completionResponse', { error: data.message })
+        } else {
+          debug('LXL: Unknown message type', data.type)
         }
       })
       ws.on('close', function close () {

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -92,6 +92,10 @@ declare module 'langxlang' {
     collectGithubRepoFiles(repo: string, options: CollectFolderOptions & {
       // The branch to use
       branch?: string,
+      // The URL to the repo, if it's not github.com
+      url?: string,
+      // The token to use for authentication, if the repo is private
+      token?: string,
     }): Promise<[absolutePath: string, relativePath: string, contents: string][]>
     // Takes output from collectFolderFiles or collectGithubRepoFiles and returns a markdown string from it
     concatFilesToMarkdown(files: [absolutePath: string, relativePath: string, contents: string][], options?: { 

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -81,6 +81,11 @@ declare module 'langxlang' {
     excluding?: Array<string | RegExp>
     // Try and cut down on the token size of the input by doing "stripping" to remove semantically unnecessary tokens from file
     strip?: StripOptions
+    // Truncate large files to this many GPT-4 tokens
+    truncateLargeFiles?: number
+    // Include binary files in the output. Binary files (<90% ASCII chars) can't be represented as text typically,
+    // so default is to exclude them.
+    includeBinaryFiles?: boolean
   }
 
   interface Tools {
@@ -95,7 +100,7 @@ declare module 'langxlang' {
       // The URL to the repo, if it's not github.com
       url?: string,
       // The token to use for authentication, if the repo is private
-      token?: string,
+      token?: string
     }): Promise<[absolutePath: string, relativePath: string, contents: string][]>
     // Takes output from collectFolderFiles or collectGithubRepoFiles and returns a markdown string from it
     concatFilesToMarkdown(files: [absolutePath: string, relativePath: string, contents: string][], options?: { 
@@ -115,7 +120,7 @@ declare module 'langxlang' {
     // replaces variables and conditionals with data from `vars`
     importPrompt(filePath: string, vars: Record<string, string>): Promise<string>
     // Reads a file from disk and returns the raw contents
-    importPromptRaw(filePath: string): Promise<string>
+    importRawSync(filePath: string): string
     // Various string manipulation tools to minify/strip down strings
     stripping: {
       stripMarkdown(input: string, options?: StripOptions): string
@@ -123,6 +128,8 @@ declare module 'langxlang' {
       normalizeLineEndings(str: string): string
       // Remove unnecessary keywords from a string
       stripJava(input: string, options?: StripOptions): string
+      // Removes files from git diff matching the options.excluding regexes
+      stripDiff(input: string, options?: { excluding: RegExp[] }): string
     }
     // Extracts code blocks from markdown
     extractCodeblockFromMarkdown(markdownInput: string): { raw: string, lang: string, code: string }[]

--- a/src/tools.js
+++ b/src/tools.js
@@ -16,6 +16,7 @@ function createTypeWriterEffectStream (to = process.stdout) {
   }, 10)
 
   return function (chunk) {
+    // console.log('chunk', chunk)
     if (chunk.done) {
       // Immediately flush whatever is left
       to.write(remainingToWrite)
@@ -52,6 +53,7 @@ module.exports = {
   preMarkdown,
   loadPrompt,
   importPromptRaw,
+  importRawSync: importPromptRaw,
   importPromptSync,
   importPrompt,
   encodeYAML: yaml.encodeYaml

--- a/src/tools/codebase.js
+++ b/src/tools/codebase.js
@@ -80,7 +80,8 @@ function collectGithubRepoFiles (repo, options) {
   const repoPath = join(reposDir, safeName)
   fs.mkdirSync(reposDir, { recursive: true })
   if (!fs.existsSync(repoPath)) {
-    cp.execSync(`git clone https://github.com/${repo}.git ${safeName}`, { cwd: reposDir })
+    const url = options.url || `https://${options.token ? options.token + '@' : ''}github.com/${repo}.git`
+    cp.execSync(`git clone ${url} ${safeName}`, { cwd: reposDir })
   }
   // Git pull origin/$branch
   cp.execSync(`git pull origin ${branch}`, { cwd: repoPath })

--- a/src/tools/codebase.js
+++ b/src/tools/codebase.js
@@ -1,8 +1,10 @@
 const fs = require('fs')
 const cp = require('child_process')
+const { isAscii, isUtf8 } = require('buffer')
 const { join } = require('path')
 const { stripJava } = require('./stripping')
 const { wrapContentWithSufficientTokens } = require('./mdp')
+const gpt4 = require('gpt-tokenizer/cjs/model/gpt-4')
 
 function fixSeparator (path) {
   return path.replace(/\\/g, '/')
@@ -28,7 +30,7 @@ function collectFolderFiles (folder, options) {
   // Now collect all the files inside repoPath, like `tree`: [absolute, relative]
   const allFiles = getAllFilesIn(folderFixed)
     .map(f => [f, f.replace(folderFixed, '')])
-  const excluding = options.excluding || ['/node_modules', '/.git']
+  const excluding = options.excluding || ['/node_modules', '/.git', /\/build\//, /\/dist\//]
 
   // Now figure out the relevant files
   const relevantFiles = []
@@ -58,16 +60,30 @@ function collectFolderFiles (folder, options) {
   }
 
   function readFile (abs) {
-    const ret = fs.readFileSync(abs, 'utf8').trim()
-    if (options.strip) {
-      if (abs.endsWith('.java')) {
-        return stripJava(ret, { stripComments: true, ...options.strip })
+    let truncated = false
+    const data = fs.readFileSync(abs)
+    if (!options.includeBinaryFiles) {
+      if (!isAscii(data) && !isUtf8(data)) {
+        return ['(binary file)', { truncated: false, binary: true }]
       }
     }
-    return ret
+    let contents = data.toString('utf-8')
+    if (options.strip) {
+      if (abs.endsWith('.java')) {
+        contents = stripJava(contents, { stripComments: true, ...options.strip })
+      }
+    }
+    if (options.truncateLargeFiles) {
+      const maxTokens = options.truncateLargeFiles
+      if (!gpt4.isWithinTokenLimit(contents, maxTokens)) {
+        contents = gpt4.decode(gpt4.encode(contents).slice(0, maxTokens))
+        truncated = true
+      }
+    }
+    return [contents, { truncated }]
   }
 
-  const fileContents = relevantFiles.map(([abs, rel]) => [abs, rel, readFile(abs)])
+  const fileContents = relevantFiles.map(([abs, rel]) => [abs, rel, ...readFile(abs)])
   return fileContents
 }
 
@@ -99,10 +115,16 @@ function concatFilesToMarkdown (files, options = {}) {
   // ...
   ```
   */
-  const acceptedExtensionsForMarkdown = ['js', 'jsx', 'ts', 'json', 'go', 'cpp', 'c', 'yaml', 'yml', 'java', 'php', 'md']
+  const acceptedExtensionsForMarkdown = ['js', 'jsx', 'ts', 'json', 'go', 'cpp', 'c', 'cpp', 'cxx', 'h', 'hpp', 'yaml', 'yml', 'java', 'php', 'md']
   let lines = ''
-  for (const [abs, rel, content] of files) {
-    lines += `${options.prefix ? options.prefix : (rel.startsWith('/') ? '' : '/')}${rel}:` + '\n'
+  for (const [abs, rel, content, meta] of files) {
+    lines += `${options.prefix ? options.prefix : (rel.startsWith('/') ? '' : '/')}${rel}`
+    if (meta.truncated) lines += ' (truncated for size)'
+    lines += ':\n'
+    if (meta.binary) {
+      lines += '(a binary file)\n'
+      continue
+    }
     // If the file contains backticks, we need to add more backticks to our wrapper for the code block to avoid markdown issues
     const codeblockExt = options.noCodeblockType ? '' : (acceptedExtensionsForMarkdown.find(ext => abs.endsWith('.' + ext)) || '')
     lines += wrapContentWithSufficientTokens(content, '`', codeblockExt)

--- a/src/tools/stripping.js
+++ b/src/tools/stripping.js
@@ -435,7 +435,10 @@ function tokenizeMarkdown (comment, options) {
     const currentChar = comment[i]
     const slice = comment.slice(i)
     if (inCodeBlock) {
-      if (slice.startsWith(inCodeBlock)) {
+      // TODO: Check markdown spec -- does \n have to proceed the code block end?
+      // Because LLMs can't backtrack to escape a codeblock with more backticks after it's started
+      // writing, we need to check \n before closing block to make sure it's actually the end
+      if (slice.startsWith('\n' + inCodeBlock)) {
         const code = tokenSoFar.slice(inCodeBlock.length + inCodeLang.length + 1) // +1 for the newline
         tokens.push([tokenSoFar + inCodeBlock, 'code', inCodeLang, code])
         i += inCodeBlock.length - 1
@@ -513,4 +516,29 @@ function stripMarkdown (comment, options = {}) {
   return result.trim()
 }
 
-module.exports = { stripJava, stripPHP, stripGo, stripMarkdown, removeNonAscii, normalizeLineEndings, tokenizeMarkdown }
+const DEFAULT_EXCLUDE = [/node_modules/, /\.git/, /\/build\//, /\/dist\//]
+
+function stripDiff (diff, options = {}) {
+  const exclude = options.exclude || DEFAULT_EXCLUDE
+  const lines = diff.split('\n')
+  const result = []
+  let inExcluded = false
+  for (const line of lines) {
+    if (line.startsWith('diff --git')) {
+      inExcluded = exclude.some((ex) => ex.test(line))
+      if (inExcluded) {
+        // Treat this as a binary file
+        result.push(line)
+        result.push('index 0000000..0000000')
+        result.push('Binary files differ')
+      }
+    }
+    if (inExcluded) {
+      continue
+    }
+    result.push(line)
+  }
+  return result.join('\n')
+}
+
+module.exports = { stripJava, stripPHP, stripGo, stripMarkdown, stripDiff, removeNonAscii, normalizeLineEndings, tokenizeMarkdown }

--- a/src/tools/stripping.js
+++ b/src/tools/stripping.js
@@ -440,8 +440,8 @@ function tokenizeMarkdown (comment, options) {
       // writing, we need to check \n before closing block to make sure it's actually the end
       if (slice.startsWith('\n' + inCodeBlock)) {
         const code = tokenSoFar.slice(inCodeBlock.length + inCodeLang.length + 1) // +1 for the newline
-        tokens.push([tokenSoFar + inCodeBlock, 'code', inCodeLang, code])
-        i += inCodeBlock.length - 1
+        tokens.push([tokenSoFar + '\n' + inCodeBlock, 'code', inCodeLang, code + '\n'])
+        i += inCodeBlock.length
         inCodeBlock = false
         tokenSoFar = ''
       } else {


### PR DESCRIPTION
* Add `stripDiff` method to minify git diffs
* Add support for truncation in collectFolderFiles and markdown generation from collected
* Handle corrupted caches (TODO: move away from raw FS)
* Fix an issue with markdown tokenization new line handling