### PR TITLE
Breaking changes to allow custom generation options and multi-completions

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ const { ChatSession, CompletionService } = require('langxlang')
 
 ```js
 const service = new CompletionService({ openai: [key], gemini: [key] })
-const response = await service.requestCompletion(
+const [response] = await service.requestCompletion(
   'gemini-1.0-pro',         //  Model name
   '',                       //  System prompt (optional)
   'Tell me about yourself'  //  User prompt

--- a/src/ChatSession.js
+++ b/src/ChatSession.js
@@ -126,11 +126,10 @@ class ChatSession {
 
   async _submitRequest (chunkCb) {
     debug('Sending to', this.model, this.messages)
-    const response = await this.service.requestStreamingChat(this.model, {
+    const [response] = await this.service.requestChatCompletion(this.model, {
       maxTokens: this.maxTokens,
       messages: this.messages,
       functions: this.functionsPayload
-      // stream: !!chunkCb
     }, chunkCb)
     debug('Streaming response', JSON.stringify(response))
     if (response.type === 'function') {
@@ -146,7 +145,7 @@ class ChatSession {
       }
       return this._submitRequest(chunkCb)
     } else if (response.type === 'text') {
-      this.messages.push({ role: 'assistant', content: response.completeMessage })
+      this.messages.push({ role: 'assistant', content: response.content })
     }
     return response
   }
@@ -174,9 +173,9 @@ class ChatSession {
           break
         }
       }
-      response.completeMessage = message.guidanceText + response.completeMessage
+      response.content = message.guidanceText + response.content
     }
-    return { text: response.completeMessage, calledFunctions: this._calledFunctionsForRound }
+    return { text: response.content, calledFunctions: this._calledFunctionsForRound }
   }
 }
 

--- a/src/Flow.js
+++ b/src/Flow.js
@@ -40,7 +40,8 @@ class Flow {
     if (runFollowUp && runFollowUp.pastResponses[inputHash]) {
       resp = structuredClone(runFollowUp.pastResponses[inputHash])
     } else {
-      resp = await this.service.requestCompletion(model, systemPrompt, userPrompt, this.chunkCb, this.generationOpts)
+      const rs = await this.service.requestCompletion(model, systemPrompt, userPrompt, this.chunkCb, this.generationOpts)
+      resp = rs[0]
     }
     resp.inputHash = inputHash
     resp.name = details.name

--- a/src/GoogleAIStudioCompletionService.js
+++ b/src/GoogleAIStudioCompletionService.js
@@ -91,7 +91,8 @@ class GoogleAIStudioCompletionService {
       throw new Error(`Model ${model} is not supported`)
     }
     const result = await this._studio.requestChatCompletion(model, messages, chunkCb, { maxTokens, functions })
-    return result
+    chunkCb?.({ done: true, delta: '\n' })
+    return [result]
   }
 }
 

--- a/src/GoogleAIStudioCompletionService.js
+++ b/src/GoogleAIStudioCompletionService.js
@@ -40,7 +40,7 @@ class GoogleAIStudioCompletionService {
       if (cachedResponse) {
         chunkCb?.({ done: false, delta: cachedResponse.text })
         chunkCb?.({ done: true, delta: '' })
-        return cachedResponse
+        return [cachedResponse]
       }
     }
 
@@ -83,7 +83,7 @@ class GoogleAIStudioCompletionService {
       }
     }
     chunkCb?.({ done: true, delta: '\n' })
-    return saveIfCaching({ text: guidance + combinedResult })
+    return [saveIfCaching({ text: guidance + combinedResult })]
   }
 
   async requestStreamingChat (model, { messages, maxTokens, functions }, chunkCb) {
@@ -91,7 +91,7 @@ class GoogleAIStudioCompletionService {
       throw new Error(`Model ${model} is not supported`)
     }
     const result = await this._studio.requestChatCompletion(model, messages, chunkCb, { maxTokens, functions })
-    return { ...result, completeMessage: result.text }
+    return result
   }
 }
 

--- a/src/GoogleAIStudioCompletionService.js
+++ b/src/GoogleAIStudioCompletionService.js
@@ -86,7 +86,7 @@ class GoogleAIStudioCompletionService {
     return [saveIfCaching({ text: guidance + combinedResult })]
   }
 
-  async requestStreamingChat (model, { messages, maxTokens, functions }, chunkCb) {
+  async requestChatCompletion (model, { messages, maxTokens, functions }, chunkCb) {
     if (!supportedModels.includes(model)) {
       throw new Error(`Model ${model} is not supported`)
     }

--- a/src/SafetyError.js
+++ b/src/SafetyError.js
@@ -1,0 +1,8 @@
+class SafetyError extends Error {
+  constructor (message) {
+    super(message)
+    this.name = 'SafetyError'
+  }
+}
+
+module.exports = SafetyError

--- a/src/gemini.js
+++ b/src/gemini.js
@@ -38,6 +38,7 @@ async function generateChatCompletionEx (model, messages, options, chunkCb) {
     contents: messages.filter(m => m.role !== 'system'),
     tools: [],
     safetySettings: options.safetySettings || defaultSafety,
+    generationConfig: options.generationConfig,
     systemInstruction: systemMessage
       ? {
           role: 'user',
@@ -68,6 +69,7 @@ async function generateChatCompletionIn (model, messages, options, chunkCb) {
     contents: messages.filter(m => m.role !== 'system'),
     tools: [],
     safetySettings: options.safetySettings || defaultSafety,
+    generationConfig: options.generationConfig,
     systemInstruction: systemMessage
       ? {
           role: 'user',

--- a/src/gemini.js
+++ b/src/gemini.js
@@ -42,7 +42,7 @@ async function generateChatCompletionEx (model, messages, options, chunkCb) {
   const stream = await generator.generateContentStream(payload)
   for await (const result of stream.stream) {
     debug('Chunk', result.text())
-    chunkCb({ content: result.text(), done: false, raw: result })
+    chunkCb?.({ content: result.text(), done: false, raw: result })
   }
   const response = await stream.response
   debug('Gemini Response', [response.text(), response.functionCalls()])
@@ -96,7 +96,6 @@ async function generateChatCompletionIn (model, messages, options, chunkCb) {
         })
       }
     } else if (candidate.finishReason === 'SAFETY') {
-      // Function call
       throw new SafetyError(`Gemini completion candidate ${candidate.index} was blocked by safety filter: ${JSON.stringify(candidate.safetyRatings)}`)
     } else {
       throw new Error(`Gemini completion candidate ${candidate.index} failed with reason: ${candidate.finishReason}`)

--- a/src/googleAIStudio.js
+++ b/src/googleAIStudio.js
@@ -202,13 +202,13 @@ function mod () {
       debug('Function call', fnName, fnArgs)
       return {
         type: 'function',
-        text: modelComment,
+        content: modelComment,
         fnCalls: [{ name: fnName, args: fnArgs }]
       }
     } else {
       return {
         type: 'text',
-        text: result
+        content: result
       }
     }
   }

--- a/src/googleAIStudio.js
+++ b/src/googleAIStudio.js
@@ -16,7 +16,7 @@ function mod () {
   let serverPromise
   let wss
 
-  let throttleTime = 6000
+  let throttleTime = 10000
   let throttle, isBusy
 
   // 1. Run a local server that a local AI Studio client can connect to

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -4,20 +4,29 @@ declare module 'langxlang' {
   type Model = 'gpt-3.5-turbo-16k' | 'gpt-3.5-turbo' | 'gpt-4' | 'gpt-4-turbo-preview' | 'gemini-1.0-pro' | 'gemini-1.5-pro'
   type ChunkCb = ({ content: string }) => void
 
+  type CompletionOptions = {
+    maxTokens: number
+    temperature: number
+    topP: number
+    topK: number
+  }
+
   class CompletionService {
     // Creates an instance of completion service.
     // Note: as an alternative to explicitly passing the API keys in the constructor you can: 
     // * set the `OPENAI_API_KEY` and `GEMINI_API_KEY` environment variables.
     // * or, define the keys inside `/.local/share/lxl-cache.json` (linux), `~/Library/Application Support/lxl-cache.json` (mac), or `%appdata%\lxl-cache.json` (windows) with the structure
     // `{"keys": {"openai": "your-openai-key", "gemini": "your-gemini-key"}}`
-    constructor(apiKeys: { openai: string, gemini: string })
+    // In this options object, you can specify generation options that will be applied by default to
+    // all requestCompletion calls. You can override these options by passing them in the requestCompletion call.
+    constructor(apiKeys: { openai: string, gemini: string }, options?: { generationOptions: CompletionOptions })
 
     cachePath: string
 
     listModels(): Promise<{ openai: Record<string, object>, google: Record<string, object> }>
 
     // Request a non-streaming completion from the model.
-    requestCompletion(model: Model, systemPrompt: string, userPrompt: string, _chunkCb?, options?: {
+    requestCompletion(model: Model, systemPrompt: string, userPrompt: string, _chunkCb?, options?: CompletionOptions & {
       // If true, the response will be cached and returned from the cache if the same request is made again.
       enableCaching?: boolean
     }): Promise<CompletionResponse[]>
@@ -41,7 +50,7 @@ declare module 'langxlang' {
     close(): void
 
     // Request a non-streaming completion from the model.
-    requestCompletion(model: Model, systemPrompt: string, userPrompt: string, chunkCb?: ChunkCb, options?: {
+    requestCompletion(model: Model, systemPrompt: string, userPrompt: string, chunkCb?: ChunkCb, options?: CompletionOptions & {
       autoFeed?: {
         // Once a line matching stopLine is hit, stop trying to feed the model more input
         stopLine: string,

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -20,7 +20,7 @@ declare module 'langxlang' {
     requestCompletion(model: Model, systemPrompt: string, userPrompt: string, _chunkCb?, options?: {
       // If true, the response will be cached and returned from the cache if the same request is made again.
       enableCaching?: boolean
-    }): Promise<CompletionResponse>
+    }): Promise<CompletionResponse[]>
   }
 
   // Note: GoogleAIStudioCompletionService does NOT use the official AI Studio API, but instead uses a relay server to forward requests to an AIStudio client.
@@ -50,7 +50,7 @@ declare module 'langxlang' {
       },
       // If true, the response will be cached and returned from the cache if the same request is made again.
       enableCaching?: boolean
-    }): Promise<CompletionResponse>
+    }): Promise<CompletionResponse[]>
   }
 
   type SomeCompletionService = CompletionService | GoogleAIStudioCompletionService

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,14 +1,14 @@
 type CompletionResponse = { text: string }
 
 declare module 'langxlang' {
-  type Model = 'gpt-3.5-turbo-16k' | 'gpt-3.5-turbo' | 'gpt-4' | 'gpt-4-turbo-preview' | 'gemini-1.0-pro' | 'gemini-1.5-pro'
+  type Model = 'gpt-3.5-turbo-16k' | 'gpt-3.5-turbo' | 'gpt-4' | 'gpt-4-turbo-preview' | 'gemini-1.0-pro' | 'gemini-1.5-pro-latest'
   type ChunkCb = ({ content: string }) => void
 
   type CompletionOptions = {
-    maxTokens: number
-    temperature: number
-    topP: number
-    topK: number
+    maxTokens?: number
+    temperature?: number
+    topP?: number
+    topK?: number
   }
 
   class CompletionService {
@@ -183,6 +183,10 @@ declare module 'langxlang' {
     constructor(completionService: CompletionService, chain: RootFlowChain, options)
     run(parameters?: Record<string, any>): Promise<FlowRun>
     followUp(priorRun: FlowRun, name: string, parameters?: Record<string, any>): Promise<FlowRun>
+  }
+
+  export class SafetyError extends Error {
+    constructor(message: string)
   }
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -7,6 +7,7 @@ const ChatSession = require('./ChatSession')
 const Flow = require('./Flow')
 const functions = require('./functions')
 const tools = require('./tools')
+const SafetyError = require('./SafetyError')
 
 module.exports = {
   appDataDir,
@@ -21,5 +22,6 @@ module.exports = {
   tools,
   importPromptSync: tools.importPromptSync,
   importPrompt: tools.importPrompt,
-  loadPrompt: tools.loadPrompt
+  loadPrompt: tools.loadPrompt,
+  SafetyError
 }

--- a/src/openai.js
+++ b/src/openai.js
@@ -50,7 +50,7 @@ function createChunkProcessor (chunkCb, resultChoices) {
           }
         } else if (delta.content) {
           resultChoice.content += delta.content
-          chunkCb?.(choice.delta)
+          chunkCb?.(choice.delta, choiceId)
         }
       } else throw new Error('Unknown chunk type')
     }

--- a/src/openai.js
+++ b/src/openai.js
@@ -9,7 +9,8 @@ async function generateCompletion (model, system, user, options = {}) {
   if (options.guidanceMessage) messages.push({ role: 'assistant', content: options.guidanceMessage })
   const completion = await openai.chat.completions.create({
     messages,
-    model
+    model,
+    ...options
   })
   const choice = completion.choices[0]
   // console.log(completion.choices[0])

--- a/src/openai.js
+++ b/src/openai.js
@@ -2,45 +2,67 @@ const OpenAI = require('openai')
 const https = require('https')
 const debug = require('debug')('lxl')
 
-async function generateCompletion (model, system, user, options = {}) {
-  const openai = new OpenAI(options)
-  const messages = [{ role: 'user', content: user }]
-  if (system) messages.unshift({ role: 'system', content: system })
-  if (options.guidanceMessage) messages.push({ role: 'assistant', content: options.guidanceMessage })
-  const completion = await openai.chat.completions.create({
-    messages,
-    model,
-    ...options
-  })
-  const choice = completion.choices[0]
-  // console.log(completion.choices[0])
-  return choice
+function createChunkProcessor (chunkCb, resultChoices) {
+  return function (chunk) {
+    if (!chunk) {
+      chunkCb?.({ done: true, delta: '' })
+      return
+    }
+    for (const choiceId in chunk.choices) {
+      const choice = chunk.choices[choiceId]
+      const resultChoice = resultChoices[choiceId] ??= { content: '', fnCalls: [], finishReason: '' }
+      if (choice.finish_reason) {
+        resultChoice.finishReason = choice.finish_reason
+      }
+      if (choice.message) {
+        resultChoice.content += choice.message.content
+      } else if (choice.delta) {
+        const delta = choice.delta
+        if (delta.tool_calls) {
+          for (const call of delta.tool_calls) {
+            resultChoice.fnCalls[call.index] ??= {
+              id: call.id,
+              name: '',
+              args: ''
+            }
+            const entry = resultChoice.fnCalls[call.index]
+            if (call.function.name) {
+              entry.name = call.function.name
+            }
+            if (call.function.arguments) {
+              entry.args += call.function.arguments
+            }
+          }
+        } else if (delta.content) {
+          resultChoice.content += delta.content
+          chunkCb?.(choice.delta)
+        }
+      } else throw new Error('Unknown chunk type')
+    }
+  }
 }
 
 // With OpenAI's Node.js SDK
-async function streamingChatCompletion (model, messages, options, chunkCb) {
+async function generateChatCompletionEx (model, messages, options, chunkCb) {
   const openai = new OpenAI(options)
-  const completion = openai.chat.completions.create({
+  const completion = await openai.chat.completions.create({
     model,
     messages,
     stream: true,
-    ...options
+    tools: options.functions || undefined,
+    tool_choice: options.functions ? 'auto' : undefined,
+    ...options.generationConfig
   })
-  let buffer = ''
+  const resultChoices = []
+  const handler = createChunkProcessor(chunkCb, resultChoices)
   for await (const chunk of completion) {
-    const choice = chunk.choices[0]
-    if (choice.delta?.content) {
-      buffer += choice.delta.content
-      chunkCb(choice.delta)
-    } else if (choice.message?.content) {
-      buffer += choice.message.content
-    }
+    handler(chunk)
   }
-  return buffer
+  return { choices: resultChoices }
 }
 
-// Over REST
-function getStreamingCompletion (apiKey, payload, completionCb) {
+// Directly use the OpenAI REST API
+function _sendApiRequest (apiKey, payload, chunkCb) {
   const chunkPrefixLen = 'data: '.length
   const options = {
     hostname: 'api.openai.com',
@@ -59,7 +81,8 @@ function getStreamingCompletion (apiKey, payload, completionCb) {
   return new Promise((resolve, reject) => {
     const req = https.request(options, (res) => {
       if (res.statusCode !== 200) {
-        console.error(`Server returned status code ${res.statusCode}`, res.statusMessage, res.headers)
+        debug(`Server returned status code ${res.statusCode}`, res.statusMessage, res.headers)
+        reject(new Error(`Server returned status code ${res.statusCode} ${res.statusMessage}`))
         return
       }
       res.setEncoding('utf-8')
@@ -73,10 +96,10 @@ function getStreamingCompletion (apiKey, payload, completionCb) {
 
           for (const line of lines) {
             if (line === 'data: [DONE]') {
-              completionCb(null)
+              chunkCb(null)
               resolve()
             } else if (line.startsWith('data: ')) {
-              completionCb(JSON.parse(line.slice(chunkPrefixLen)))
+              chunkCb(JSON.parse(line.slice(chunkPrefixLen)))
             }
           }
         })
@@ -85,7 +108,7 @@ function getStreamingCompletion (apiKey, payload, completionCb) {
           buffer += chunk
         })
         res.on('end', () => {
-          completionCb(JSON.parse(buffer))
+          chunkCb(JSON.parse(buffer))
           resolve()
         })
       }
@@ -99,10 +122,45 @@ function getStreamingCompletion (apiKey, payload, completionCb) {
   })
 }
 
+async function generateChatCompletionIn (model, messages, options, chunkCb) {
+  const resultChoices = []
+  await _sendApiRequest(options.apiKey, {
+    model,
+    ...options.generationConfig,
+    messages,
+    stream: true,
+    tools: options.functions || undefined,
+    tool_choice: options.functions ? 'auto' : undefined
+  }, createChunkProcessor(chunkCb, resultChoices))
+  return { choices: resultChoices }
+}
+
+async function generateCompletion (model, system, user, options = {}) {
+  const messages = [{ role: 'user', content: user }]
+  if (system) messages.unshift({ role: 'system', content: system })
+  if (options.guidanceMessage) messages.push({ role: 'assistant', content: options.guidanceMessage })
+  const completion = await generateChatCompletionIn(model, messages, options)
+  debug('OpenAI Completion', JSON.stringify(completion))
+  const choice = completion.choices[0]
+  return choice
+}
+
 async function listModels (apiKey) {
   const openai = new OpenAI({ apiKey })
   const list = await openai.models.list()
   return list.body.data
 }
 
-module.exports = { generateCompletion, getStreamingCompletion, streamingChatCompletion, listModels }
+module.exports = { generateCompletion, generateChatCompletionEx, generateChatCompletionIn, listModels }
+
+/*
+via https://platform.openai.com/docs/guides/text-generation/chat-completions-api
+
+Every response will include a finish_reason. The possible values for finish_reason are:
+
+stop: API returned complete message, or a message terminated by one of the stop sequences provided via the stop parameter
+length: Incomplete model output due to max_tokens parameter or token limit
+function_call: The model decided to call a function
+content_filter: Omitted content due to a flag from our content filters
+null: API response still in progress or incomplete
+*/

--- a/src/tools.js
+++ b/src/tools.js
@@ -16,7 +16,6 @@ function createTypeWriterEffectStream (to = process.stdout) {
   }, 10)
 
   return function (chunk) {
-    // console.log('chunk', chunk)
     if (chunk.done) {
       // Immediately flush whatever is left
       to.write(remainingToWrite)

--- a/src/util.js
+++ b/src/util.js
@@ -1,5 +1,6 @@
 function cleanMessage (msg) {
   if (!msg) return msg
+  if (msg.constructor.name === 'PromptString') return msg
   // fix systemMessage \r\n to \n
   return msg.replace(/\r\n/g, '\n')
 }

--- a/test/api.js
+++ b/test/api.js
@@ -2,6 +2,7 @@
 // @ts-check
 const { CompletionService, ChatSession, Func: { Arg, Desc }, loadPrompt } = require('langxlang')
 const fs = require('fs')
+const assert = require('assert')
 const openAIKey = fs.readFileSync('openai.key', 'utf8')
 const geminiKey = fs.readFileSync('gemini.key', 'utf8')
 const guidanceStr = `Please convert this YAML to JSON:
@@ -42,14 +43,16 @@ async function testGeminiCompletion (model = 'gemini-1.0-pro') {
 }
 
 async function testGuidance () {
-  console.log('Guidance:', guidanceStr)
+  // EXPECTED = '```json\n{\n  "name": "AI",\n  "age": 30\n}\n```'
   const q = loadPrompt(guidanceStr, {})
-  const result = await completionService.requestCompletion('gpt-3.5-turbo', '', q)
+  const [result] = await completionService.requestCompletion('gpt-3.5-turbo', '', q)
   console.log('GPT-3.5 result for', q)
   console.log(result)
-  const result2 = await completionService.requestCompletion('gemini-1.0-pro', '', q)
+  assert(result.text.trim().startsWith('```json\n') && result.text.trim().endsWith('```'), 'Guidance not followed by GPT-3.5')
+  const [result2] = await completionService.requestCompletion('gemini-1.0-pro', '', q)
   console.log('Gemini result for', q)
   console.log(result2)
+  assert(result.text.trim().startsWith('```json\n') && result.text.trim().endsWith('```'), 'Guidance not followed by Gemini 1.0')
 }
 
 function toTerminal (chunk) {

--- a/test/api.js
+++ b/test/api.js
@@ -139,6 +139,22 @@ async function testOpenAICaching () {
   console.log(result)
 }
 
+async function testOptions () {
+  const q = 'Hello! Why is the sky blue?'
+  console.log('OptionsTest>', q)
+  const [resultGpt] = await completionService.requestCompletion('gpt-3.5-turbo', '', 'Hello! Why is the sky blue?', null, {
+    maxTokens: 100,
+    temperature: 2
+  })
+  console.log('GPT-3.5 with maxTokens=100, temp=2', resultGpt)
+  console.log(resultGpt)
+  const [resultGemini] = await completionService.requestCompletion('gemini-1.0-pro', '', 'Hello! Why is the sky blue?', null, {
+    maxTokens: 100,
+    temperature: 2
+  })
+  console.log('Gemini 1.0 Pro with maxTokens=100, temp=2', resultGemini)
+}
+
 async function testBasic () {
   await testListing()
   await testOpenAICompletion()
@@ -151,6 +167,7 @@ async function testBasic () {
   await testGeminiSessionWithFuncs('gemini-1.0-pro')
   await testGeminiSessionWithFuncs('gemini-1.5-pro-latest')
   await testOpenAICaching()
+  await testOptions()
 
   console.log('All Good!')
 }

--- a/test/flow.test.js
+++ b/test/flow.test.js
@@ -48,11 +48,11 @@ const dummyCompletionService = {
     const mergedPrompt = [systemPrompt, userPrompt].join('\n')
     // console.log('mergedPrompt', mergedPrompt)
     if (mergedPrompt.includes('YAML')) {
-      return { text: 'Sure! Here is some yaml:\n```yaml\nare_ok: yes\n```\nI hope that helps!' }
+      return [{ text: 'Sure! Here is some yaml:\n```yaml\nare_ok: yes\n```\nI hope that helps!' }]
     } else if (mergedPrompt.includes('tomorrow')) {
-      return { text: 'Tomorrow is Tuesday.' }
+      return [{ text: 'Tomorrow is Tuesday.' }]
     } else {
-      return { text: `You asked: "${JSON.stringify(mergedPrompt)}".\n` }
+      return [{ text: `You asked: "${JSON.stringify(mergedPrompt)}".\n` }]
     }
   }
 }

--- a/test/googleaistudio.js
+++ b/test/googleaistudio.js
@@ -43,7 +43,7 @@ async function testCompletionChat () {
   const service = new GoogleAIStudioCompletionService(8095)
   await service.ready
 
-  const [result] = await service.requestStreamingChat('gemini-1.5-pro', {
+  const [result] = await service.requestChatCompletion('gemini-1.5-pro', {
     messages: [{ role: 'user', content: 'How are you doing today?' }]
   }, pleasantWriter())
   console.log('Result', result.content)

--- a/test/googleaistudio.js
+++ b/test/googleaistudio.js
@@ -12,13 +12,13 @@ async function testCompletion () {
 
   const q1 = 'Why is the sky blue?'
   console.log('>', q1)
-  const result = await service.requestCompletion('gemini-1.5-pro', '', q1, pleasantWriter())
+  const [result] = await service.requestCompletion('gemini-1.5-pro', '', q1, pleasantWriter())
   process.stdout.write('\n')
   console.log('Result 1', result.text)
 
   const q2 = 'When do you think we will first land humans on Mars?'
   console.log('>', q2)
-  const result2 = await service.requestCompletion('gemini-1.5-pro', '', q2, pleasantWriter())
+  const [result2] = await service.requestCompletion('gemini-1.5-pro', '', q2, pleasantWriter())
   process.stdout.write('\n')
   console.log('Result 2', result2.text)
 
@@ -31,7 +31,7 @@ async function testCachedCompletion () {
 
   const q1 = 'Why is the sky blue?'
   console.log('>', q1)
-  const result = await service.requestCompletion('gemini-1.5-pro', '', q1, pleasantWriter(), {
+  const [result] = await service.requestCompletion('gemini-1.5-pro', '', q1, pleasantWriter(), {
     enableCaching: true
   })
   console.log('Cached Result 1', result)
@@ -43,10 +43,10 @@ async function testCompletionChat () {
   const service = new GoogleAIStudioCompletionService(8095)
   await service.ready
 
-  const result = await service.requestStreamingChat('gemini-1.5-pro', {
+  const [result] = await service.requestStreamingChat('gemini-1.5-pro', {
     messages: [{ role: 'user', content: 'How are you doing today?' }]
   }, pleasantWriter())
-  console.log('Result', result.text)
+  console.log('Result', result.content)
   service.stop()
 }
 


### PR DESCRIPTION
BREAKING:
* CompletionService and GoogleAIStudioCompletionService
  * `.requestCompletion` now returns an array of completions

Non-brekaing:
`.requestCompletion`'s options objects now also take in the following options:
```coffee
    maxTokens: number
    temperature: number
    topP: number
    topK: number
```

Which will be passed to the model's generation options.

The constructors for CompletionService and GoogleAIStudioCompletionService have also been updated to take an additional objects object. These the object can contain a `generationOptions` dictionary that will be applied by default to all requestCompletion calls. You can override these options by passing them in individual requestCompletion calls.

Export a `SafetyError` object that can be used in instanceof checks to see if a model response failed due content filtering rules.