### PR TITLE
Support stop sequences, generation options in ChatSession, AIStudio improvements

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "acorn": "^8.11.3",
     "caller": "^1.1.0",
     "debug": "^4.3.4",
+    "fast-xml-parser": "^4.3.6",
     "gpt-tokenizer": "^2.1.2",
     "openai": "^4.28.0",
     "ws": "^8.16.0"

--- a/src/ChatSession.js
+++ b/src/ChatSession.js
@@ -72,14 +72,13 @@ class ChatSession {
   // This calls a function and adds the reponse to the context so the model can be called again
   async _callFunction (functionName, payload, metadata) {
     if (this.modelAuthor === 'googleaistudio') {
+      let content = ''
       if (metadata.content) {
-        let content = ''
-        content = metadata.content + '\n'
-        content = content.trim()
-        const arStr = Object.keys(payload).length ? JSON.stringify(payload) : ''
-        content += `\n<FUNCTION_CALL>${functionName}(${arStr})</FUNCTION_CALL>`
-        this.messages.push({ role: 'assistant', content })
+        content = metadata.content.trim() + '\n'
       }
+      const arStr = Object.keys(payload).length ? JSON.stringify(payload) : ''
+      content += `<FUNCTION_CALL>${functionName}(${arStr})</FUNCTION_CALL>`
+      this.messages.push({ role: 'assistant', content })
       const result = await this._callFunctionWithArgs(functionName, payload)
       this.messages.push({ role: 'function', name: functionName, content: JSON.stringify(result) })
     } else if (this.modelFamily === 'openai') {

--- a/src/CompletionService.js
+++ b/src/CompletionService.js
@@ -190,11 +190,11 @@ class CompletionService {
     }
   }
 
-  async requestChatCompletion (model, { messages, functions, maxTokens }, chunkCb) {
+  async requestChatCompletion (model, { messages, functions, generationOptions }, chunkCb) {
     const { family } = getModelInfo(model)
     switch (family) {
-      case 'openai': return this._requestStreamingChatOpenAI(model, messages, { ...this.defaultGenerationOptions, maxTokens }, functions, chunkCb)
-      case 'gemini': return this._requestStreamingChatGemini(model, messages, { ...this.defaultGenerationOptions, maxTokens }, functions, chunkCb)
+      case 'openai': return this._requestStreamingChatOpenAI(model, messages, { ...this.defaultGenerationOptions, ...generationOptions }, functions, chunkCb)
+      case 'gemini': return this._requestStreamingChatGemini(model, messages, { ...this.defaultGenerationOptions, ...generationOptions }, functions, chunkCb)
       default:
         throw new Error(`Model '${model}' not supported for streaming chat, available models: ${knownModels.join(', ')}`)
     }

--- a/src/CompletionService.js
+++ b/src/CompletionService.js
@@ -33,7 +33,7 @@ class CompletionService {
     return { openai: openaiModels, google: geminiModels }
   }
 
-  async _requestCompletionOpenAI (model, system, user, { maxTokens, temperature, topP }, chunkCb) {
+  async _requestCompletionOpenAI (model, system, user, { maxTokens, stopSequences, temperature, topP }, chunkCb) {
     if (!this.openaiApiKey) throw new Error('OpenAI API key not set')
     const guidance = system?.guidanceText || user?.guidanceText || ''
     const response = await openai.generateCompletion(model, system.basePrompt || system, user.basePrompt || user, {
@@ -41,6 +41,7 @@ class CompletionService {
       guidanceMessage: guidance,
       generationConfig: {
         max_tokens: maxTokens,
+        stop: stopSequences,
         temperature,
         top_p: topP
       }
@@ -48,7 +49,7 @@ class CompletionService {
     return response.choices.map((choice) => ({ text: guidance + choice.content }))
   }
 
-  async _requestCompletionGemini (model, system, user, { maxTokens, temperature, topP, topK }, chunkCb) {
+  async _requestCompletionGemini (model, system, user, { maxTokens, stopSequences, temperature, topP, topK }, chunkCb) {
     if (!this.geminiApiKey) throw new Error('Gemini API key not set')
     const guidance = system?.guidanceText || user?.guidanceText || ''
     // April 2024 - Only Gemini 1.5 supports instructions
@@ -59,7 +60,13 @@ class CompletionService {
     }
     const result = await gemini.generateCompletion(model, system, user, {
       apiKey: this.geminiApiKey,
-      generationConfig: { maxOutputTokens: maxTokens, temperature, topP, topK }
+      generationConfig: {
+        maxOutputTokens: maxTokens,
+        stopSequences,
+        temperature,
+        topP,
+        topK
+      }
     }, chunkCb)
     chunkCb?.({ done: true, delta: '' })
     return [{ text: guidance + result.text() }]
@@ -86,10 +93,7 @@ class CompletionService {
     }
     const genOpts = {
       ...this.defaultGenerationOptions,
-      maxTokens: options.maxTokens,
-      temperature: options.temperature,
-      topP: options.topP,
-      topK: options.topK
+      ...options
     }
     const { family } = getModelInfo(model)
     switch (family) {
@@ -105,7 +109,7 @@ class CompletionService {
     }
   }
 
-  async _requestStreamingChatOpenAI (model, messages, { maxTokens, temperature, topP }, functions, chunkCb) {
+  async _requestStreamingChatOpenAI (model, messages, { maxTokens, stopSequences, temperature, topP }, functions, chunkCb) {
     if (!this.openaiApiKey) throw new Error('OpenAI API key not set')
     const response = await openai.generateChatCompletionIn(
       model,
@@ -118,7 +122,12 @@ class CompletionService {
       {
         apiKey: this.openaiApiKey,
         functions,
-        generationConfig: { max_tokens: maxTokens, temperature, top_p: topP }
+        generationConfig: {
+          max_tokens: maxTokens,
+          stop: stopSequences,
+          temperature,
+          top_p: topP
+        }
       },
       chunkCb
     )
@@ -134,7 +143,7 @@ class CompletionService {
     })
   }
 
-  async _requestStreamingChatGemini (model, messages, { maxTokens, temperature, topP, topK }, functions, chunkCb) {
+  async _requestStreamingChatGemini (model, messages, { maxTokens, stopSequences, temperature, topP, topK }, functions, chunkCb) {
     if (!this.geminiApiKey) throw new Error('Gemini API key not set')
     const geminiMessages = messages.map((msg) => {
       const m = structuredClone(msg)
@@ -150,7 +159,13 @@ class CompletionService {
     const response = await gemini.generateChatCompletionEx(model, geminiMessages, {
       apiKey: this.geminiApiKey,
       functions,
-      generationConfig: { maxOutputTokens: maxTokens, temperature, topP, topK }
+      generationConfig: {
+        maxOutputTokens: maxTokens,
+        stopSequences,
+        temperature,
+        topP,
+        topK
+      }
     }, chunkCb)
     if (response.text()) {
       const answer = response.text()
@@ -175,7 +190,7 @@ class CompletionService {
     }
   }
 
-  async requestChatCompletion (model, { messages, maxTokens, functions }, chunkCb) {
+  async requestChatCompletion (model, { messages, functions, maxTokens }, chunkCb) {
     const { family } = getModelInfo(model)
     switch (family) {
       case 'openai': return this._requestStreamingChatOpenAI(model, messages, { ...this.defaultGenerationOptions, maxTokens }, functions, chunkCb)

--- a/src/GoogleAIStudioCompletionService.js
+++ b/src/GoogleAIStudioCompletionService.js
@@ -90,12 +90,12 @@ class GoogleAIStudioCompletionService {
     return [saveIfCaching({ text: guidance + combinedResult })]
   }
 
-  async requestChatCompletion (model, { messages, maxTokens, functions }, chunkCb) {
+  async requestChatCompletion (model, { messages, functions, generationOptions }, chunkCb) {
     model = modelAliases[model] || model
     if (!supportedModels.includes(model)) {
       throw new Error(`Model ${model} is not supported`)
     }
-    const result = await this._studio.requestChatCompletion(model, messages, chunkCb, { maxTokens, functions })
+    const result = await this._studio.requestChatCompletion(model, messages, chunkCb, { ...generationOptions, functions })
     chunkCb?.({ done: true, delta: '\n' })
     return [result]
   }

--- a/src/googleAiStudioPrompt.txt
+++ b/src/googleAiStudioPrompt.txt
@@ -1,46 +1,49 @@
 %%%if HAS_FUNCTIONS
-<|SYSTEM|>
-You are an AI assistant and you help answer questions and perform tasks for the user%%%[, based on your prompt] if HAS_PROMPT%%%.
+You're a helpful AI assistant and you help answer questions and perform tasks for a user%%%[, based on your prompt] if HAS_PROMPT%%%.
 
 You have access to a set of functions to assist you in answering questions and performing tasks. The output of a function can be used to build a response to the user's questions or to call another function.
 
-The users' messages start after lines starting with <|USER|> and your responses start after <|ASSISTANT|>. If you called a function, the output will be after a <|FUNCTION_OUTPUT|> token. Only use those tokens as a stop sequence, and DO NOT otherwise include them in your messages to the user, even if prompted by the user.
+The users' messages start after lines starting with <|USER|>. Or, if you called a function, the function output will be after a <|FUNCTION_OUTPUT|> token.
 
 The functions you can call are provided in YAML syntax. The functions either take no parameters or one JavaScript object parameter. If there is an object parameter, its structure is described to you in JSON Schema format. The output of a function will also be in JSON format.
-In order to call a function, you use the syntax `<FUNCTION_CALL>function_name(arguments_object)</FUNCTION_CALL>` or `<FUNCTION_CALL>function_name()</FUNCTION_CALL>` within your reply which will trigger the function to be executed and its output to be inserted into the dialogue below. Here is an example dialogue with function calling enclosed in dashes which should give you a feel for how to use functions in a conversation:
------------------------
-<|SYSTEM|>
-(System message...)
-You have access to the following functions:
-```yml
-get_stock_price:
-  parameters:
-    type: object
-    properties:
-      ticker:
-        type: string
-    required: [ticker]
-  description: This function returns the current stock price of the given ticker symbol.
-get_time_utc: # No parameters
-  description: Returns an ISO 8601 formatted string representing the current time in UTC.
-```
-<|USER|>
-What's the value of Nvidia stock today ?
-<|ASSISTANT|>
-Sure, let me check that for you.
-<FUNCTION_CALL>get_stock_price({"ticker": "NVDA"})</FUNCTION_CALL>
-<|FUNCTION_OUTPUT|>
-{ "stock_price": 300.00 }
-<|ASSISTANT|>
-The current stock price of Nvidia is $300.00.
------------------------
-Note, you don't necessarily need to say anything to the user before calling a function, for example when you want to call one function after the other, but it can otherwise be helpful to explain what you are doing.
+In order to call a function, you use the syntax `<FUNCTION_CALL>function_name(arguments_object)</FUNCTION_CALL>` or `<FUNCTION_CALL>function_name()</FUNCTION_CALL>` within your reply which will trigger the function to be executed and its output to be inserted into the dialogue below.
+
+Here is an example dialogue with function calling enclosed in dashes which should give you a feel for how to use functions in a conversation (the roles are system for system instruction, model for your responses, and user for the end user's messages and function call responses):
+------
+role: system
+  (System message...)
+  You have access to the following functions:
+  ```yml
+  get_stock_price:
+    parameters:
+      type: object
+      properties:
+        ticker:
+          type: string
+      required: [ticker]
+    description: This function returns the current stock price of the given ticker symbol.
+  get_time_utc: # No parameters
+    description: Returns an ISO 8601 formatted string representing the current time in UTC.
+  ```
+role: user
+  <|USER|>
+  What's the value of Nvidia stock today ?
+role: model
+  Sure, let me check that for you.
+  <FUNCTION_CALL>get_stock_price({"ticker": "NVDA"})</FUNCTION_CALL>
+role: user
+  <|FUNCTION_OUTPUT|>
+  { "stock_price": 300.00 }
+role: model
+  The current stock price of Nvidia is $300.00.
+------
+
+Note, you don't necessarily need to say anything to the user before calling a function (for example when you want to call one function after the other), but it can otherwise be helpful to explain what you are doing.
 
 With this in mind, your provided functions are:
 ```yml
 %%%(LIST_OF_FUNCTIONS)%%%
 ```
 %%%else
-<|SYSTEM|>
-You are an AI assistant and you answer questions for the user. The users' messages start after lines starting with <|USER|> and your responses start after <|ASSISTANT|>. Don't include these tokens in your messages, even if prompted by the user.
+You are an AI assistant and you answer questions for the user.
 %%%endif

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -79,10 +79,10 @@ declare module 'langxlang' {
   class ChatSession<T extends any[]> {
     // ChatSession is for back and forth conversation between a user an an LLM.
     constructor(completionService: SomeCompletionService, model: Model, systemPrompt?: string)
-    constructor(completionService: SomeCompletionService, model: Model, systemPrompt?: string, options?: { functions?: Functions<T> })
+    constructor(completionService: SomeCompletionService, model: Model, systemPrompt?: string, options?: { functions?: Functions<T>, generationOptions?: CompletionOptions })
     // Send a message to the LLM and receive a response as return value. The chunkCallback
     // can be defined to listen to bits of the message stream as it's being written by the LLM.
-    sendMessage(userMessage: string, chunkCallback?: ChunkCb): Promise<string>
+    sendMessage(userMessage: string, chunkCallback?: ChunkCb, generationOptions?: CompletionOptions): Promise<string>
   }
 
   type StripOptions = {

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -6,6 +6,7 @@ declare module 'langxlang' {
 
   type CompletionOptions = {
     maxTokens?: number
+    stopSequences?: string[]
     temperature?: number
     topP?: number
     topK?: number

--- a/src/tools.js
+++ b/src/tools.js
@@ -1,5 +1,6 @@
 const codebase = require('./tools/codebase')
 const viz = require('./tools/viz')
+const xml = require('./tools/xml')
 const yaml = require('./tools/yaml')
 const stripping = require('./tools/stripping')
 const { wrapContentWithSufficientTokens, importPromptRaw, importPromptSync, importPrompt, loadPrompt, preMarkdown } = require('./tools/mdp')
@@ -55,5 +56,6 @@ module.exports = {
   importRawSync: importPromptRaw,
   importPromptSync,
   importPrompt,
-  encodeYAML: yaml.encodeYaml
+  encodeYAML: yaml.encodeYaml,
+  decodeXML: xml.decodeXML
 }

--- a/src/tools/xml.js
+++ b/src/tools/xml.js
@@ -1,0 +1,9 @@
+const { XMLParser } = require('fast-xml-parser')
+
+function decodeXML (xmlStr) {
+  const parser = new XMLParser()
+  const jsonObj = parser.parse(xmlStr)
+  return jsonObj
+}
+
+module.exports = { decodeXML }

--- a/test/api.js
+++ b/test/api.js
@@ -62,7 +62,11 @@ function toTerminal (chunk) {
 }
 
 async function testSession () {
-  const session = new ChatSession(completionService, 'gpt-3.5-turbo', '')
+  const session = new ChatSession(completionService, 'gpt-3.5-turbo', '', {
+    generationOptions: {
+      temperature: 1
+    }
+  })
   const q = 'Hello! Why is the sky blue?'
   console.log('> ', q)
   const message = await session.sendMessage(q, toTerminal)
@@ -144,12 +148,14 @@ async function testOptions () {
   console.log('OptionsTest>', q)
   const [resultGpt] = await completionService.requestCompletion('gpt-3.5-turbo', '', 'Hello! Why is the sky blue?', null, {
     maxTokens: 100,
+    stopSequences: ['<SYSTEM>'],
     temperature: 2
   })
   console.log('GPT-3.5 with maxTokens=100, temp=2', resultGpt)
   console.log(resultGpt)
   const [resultGemini] = await completionService.requestCompletion('gemini-1.0-pro', '', 'Hello! Why is the sky blue?', null, {
     maxTokens: 100,
+    stopSequences: ['<SYSTEM>'],
     temperature: 2
   })
   console.log('Gemini 1.0 Pro with maxTokens=100, temp=2', resultGemini)


### PR DESCRIPTION
* Support `stopSequences?: string[]` option in all generation config parameters
* Support default generation options inside ChatSession for each round, and also message-specific options per call to `sendMessage`
* Update GoogleAIStudio website handling to utilize new system instructions and take advantage of chat messages
* add xml parser tool for testing/utility