### PR TITLE
tools: Improvements to stripping and code collection, add a token counting bin script

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![Gitpod ready-to-code](https://img.shields.io/badge/Gitpod-ready--to--code-blue?logo=gitpod)](https://gitpod.io/#https://github.com/extremeheat/LXL)
 
 LangXLang (LXL) is a Node.js library and toolkit for using large language models (LLMs) inside software applications.
+
 LXL supports function calling, caching, prompt templating role play, and building complex conversational flows with LLMs.
 
 Supported models are:

--- a/README.md
+++ b/README.md
@@ -3,7 +3,8 @@
 [![Build Status](https://github.com/extremeheat/LXL/actions/workflows/ci.yml/badge.svg)](https://github.com/extremeheat/LXL/actions/workflows/)
 [![Gitpod ready-to-code](https://img.shields.io/badge/Gitpod-ready--to--code-blue?logo=gitpod)](https://gitpod.io/#https://github.com/extremeheat/LXL)
 
-LangXLang (LXL), a Node.js library to use OpenAI's GPT models and Google's Gemini and PaLM 2 models, with function calling support.
+LangXLang (LXL) is a Node.js library and toolkit for using large language models (LLMs) inside software applications.
+LXL supports function calling, caching, prompt templating role play, and building complex conversational flows with LLMs.
 
 Supported models are:
 * OpenAI: `gpt-3.5-turbo-16k`, `gpt-3.5-turbo`, `gpt-4`, `gpt-4-turbo-preview` (or any specific gpt- model listed [here](https://platform.openai.com/docs/models/))

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -1,0 +1,39 @@
+#!/usr/bin/env node
+const gpt4 = require('gpt-tokenizer/cjs/model/gpt-4')
+
+function countTokens (text) {
+  return gpt4.encode(text).length
+}
+
+function raise (msg) {
+  if (msg) console.error(msg)
+  console.error('Usage: langxlang <command> ...args')
+  console.error('Usage: langxlang count <tokenizer> <file>')
+  console.error('Example: langxlang count gpt4 myfile.js')
+}
+
+if (process.argv.length < 3) {
+  raise()
+  process.exit(1)
+}
+
+const commands = {
+  count (tokenizer, file) {
+    if (!tokenizer || !file) {
+      raise('Must supply both a tokenizer (like gpt4) and a file')
+      process.exit(1)
+    }
+    console.log('Counting tokens in', file, 'using', tokenizer)
+    if (tokenizer === 'gpt4') {
+      const text = require('fs').readFileSync(file, 'utf8')
+      console.log('Tokens:', countTokens(text).toLocaleString())
+    } else {
+      console.error('Unknown tokenizer', tokenizer)
+      process.exit(1)
+    }
+  }
+}
+
+const [, , command, ...args] = process.argv
+console.error(`command: ${command}`, args)
+commands[command](...args)

--- a/package.json
+++ b/package.json
@@ -4,6 +4,9 @@
   "description": "LLM wrapper for OpenAI GPT and Google Gemini and PaLM 2 models",
   "main": "src/index.js",
   "types": "src/index.d.ts",
+  "bin": {
+    "langxlang": "bin/cli.js"
+  },
   "scripts": {
     "test": "npm run mocha",
     "pretest": "npm run lint",

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -29,7 +29,7 @@ declare module 'langxlang' {
     listModels(): Promise<{ openai: Record<string, object>, google: Record<string, object> }>
 
     // Request a completion from the model with a system prompt and a single user prompt.
-    requestCompletion(model: Model, systemPrompt: string, userPrompt: string, _chunkCb?, options?: CompletionOptions & {
+    requestCompletion(model: Model, systemPrompt: string, userPrompt: string, _chunkCb?: ChunkCb, options?: CompletionOptions & {
       // If true, the response will be cached and returned from the cache if the same request is made again.
       enableCaching?: boolean
     }): Promise<CompletionResponse[]>

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -101,10 +101,11 @@ declare module 'langxlang' {
   interface CollectFolderOptions {
     // What extension/extension(s) of files in the repo to include
     extension?: string | string[]
-    // Either a function that returns true if the file should be included
-    // or an array of regexes of which one needs to match for inclusion
-    matching?: (fileName: string) => boolean | RegExp[]
+    // Either a function that returns true if the file should be included, or false if not (otherwise the call result is ignored).
+    // OR alternatively, pass an array of regexes of which one needs to match for inclusion.
+    matching?: ((relativePath: string, absolutePath: string, wouldBeExcluded: boolean) => boolean) | RegExp[]
     // An optional list of strings for which if the path starts with one of them, it's excluded, even if it was matched by `extension` or `matching`
+    // unless `matching` was a function and it explicitly returned `true` for the file.
     excluding?: Array<string | RegExp>
     // Try and cut down on the token size of the input by doing "stripping" to remove semantically unnecessary tokens from file
     strip?: StripOptions
@@ -122,7 +123,7 @@ declare module 'langxlang' {
     collectFolderFiles(folderPath: string, options: CollectFolderOptions): Promise<[absolutePath: string, relativePath: string, contents: string][]>
     // Returns a JS object with a list of files in a GitHub repo
     collectGithubRepoFiles(repo: string, options: CollectFolderOptions & {
-      // The branch to use
+      // The branch or ref to use
       branch?: string,
       // The URL to the repo, if it's not github.com
       url?: string,
@@ -160,7 +161,7 @@ declare module 'langxlang' {
       // Normalize line endings to \n
       normalizeLineEndings(str: string): string
       // Remove unnecessary keywords from a string
-      stripJava(input: string, options?: StripOptions): string
+      stripJava(input: string, options?: StripOptions & { removeStrings?: boolean }): string
       // Removes files from git diff matching the options.excluding regexes
       stripDiff(input: string, options?: { excluding: RegExp[] }): string
     }

--- a/src/tools/codebase.js
+++ b/src/tools/codebase.js
@@ -94,7 +94,7 @@ function collectFolderFiles (folder, options) {
 
 // This function will clone a github repo, review all the files and merge relevant files into a single file
 function collectGithubRepoFiles (repo, options) {
-  const exec = (cmd, args) => (options.verbose ? console.log('$', cmd, args) : null, cp.execSync(cmd, args))
+  const exec = (cmd, args) => (options.verbose ? console.log('$', cmd, args) : null, cp.execSync(cmd, args)) // eslint-disable-line no-sequences
   // First, try to clone the repo inside a "repos" folder in this directory
   const safeName = repo.replace(/\//g, ',')
   const reposDir = join(__dirname, 'repos')

--- a/src/tools/codebase.js
+++ b/src/tools/codebase.js
@@ -40,9 +40,14 @@ function collectFolderFiles (folder, options) {
     } else if (extension && !file.endsWith(extension)) {
       continue
     }
+    const wouldBeExcluded = excluding.some(ex => (typeof ex === 'string') ? relFile.startsWith(ex) : relFile.match(ex))
     if (options.matching) {
       if (typeof options.matching === 'function') {
-        if (!options.matching(relFile)) {
+        const matching = options.matching(relFile, file, wouldBeExcluded)
+        if (matching === false) {
+          continue
+        } else if (matching === true) {
+          relevantFiles.push([file, relFile])
           continue
         }
       } else if (Array.isArray(options.matching)) {
@@ -53,7 +58,7 @@ function collectFolderFiles (folder, options) {
         throw new Error('options.matching must be a function or an array of regexes or strings')
       }
     }
-    if (excluding.some(ex => (typeof ex === 'string') ? relFile.startsWith(ex) : relFile.match(ex))) {
+    if (wouldBeExcluded) {
       continue
     }
     relevantFiles.push([file, relFile])
@@ -89,7 +94,7 @@ function collectFolderFiles (folder, options) {
 
 // This function will clone a github repo, review all the files and merge relevant files into a single file
 function collectGithubRepoFiles (repo, options) {
-  const branch = options.branch || 'master'
+  const exec = (cmd, args) => (options.verbose ? console.log('$', cmd, args) : null, cp.execSync(cmd, args))
   // First, try to clone the repo inside a "repos" folder in this directory
   const safeName = repo.replace(/\//g, ',')
   const reposDir = join(__dirname, 'repos')
@@ -97,12 +102,15 @@ function collectGithubRepoFiles (repo, options) {
   fs.mkdirSync(reposDir, { recursive: true })
   if (!fs.existsSync(repoPath)) {
     const url = options.url || `https://${options.token ? options.token + '@' : ''}github.com/${repo}.git`
-    cp.execSync(`git clone ${url} ${safeName} --depth 1`, { cwd: reposDir })
+    exec(`git clone ${url} ${safeName} --depth 1`, { cwd: reposDir })
   }
+  const defaultBranch = exec('git rev-parse --abbrev-ref HEAD', { cwd: repoPath }).toString().trim()
+  const branch = options.branch || defaultBranch
+  const baseRef = branch.replace(/\^|~/g, '')
   // Git pull origin/$branch
-  cp.execSync(`git pull origin ${branch}`, { cwd: repoPath })
+  exec(`git fetch origin "${baseRef}"`, { cwd: repoPath })
   // Check out the branch
-  cp.execSync(`git checkout ${branch}`, { cwd: repoPath })
+  exec(`git checkout "${branch}"`, { cwd: repoPath })
   return collectFolderFiles(repoPath, options)
 }
 

--- a/test/tooling.test.js
+++ b/test/tooling.test.js
@@ -65,6 +65,15 @@ describe('stripping', function () {
     assert.strictEqual(block.raw.length, 867)
     assert.strictEqual(block.code.length, 858)
   })
+  it('on java', function () {
+    const s = `
+public static final EntityType<Boat> BOAT = register(
+  "boat", EntityType.Builder.<Boat>of(Boat::new, MobCategory.MISC).sized(1.375F, 0.5625F).eyeHeight(0.5625F).clientTrackingRange(10)
+)`
+    const strip = tools.stripping.stripJava(s, { removeComments: true, removeAnnotations: true, removeStrings: false })
+    // ~mostly the same but with some syntax modifiers removed
+    assert.strictEqual(s.trim().replace('public static final', 'static'), strip.trim())
+  })
 })
 
 const testObject = {


### PR DESCRIPTION
Stripping
* Fix java stripping annotations not working correctly
* Allow stripping comments with option.stripComments in tools.stripping.stripJava
* Support stripping java code in git diffs when using `tools.stripping.stripDiff`

Collect codebase
* Support caret and tilde for git refs in `branch` option (for example to get one commit before a commit hash like HEAD, set `HEAD^`, or n commits with `HEAD~n` as `branch` option)
* Use correct default branch if not specified
* option.matching function has been updated for more fine grained control when used with `options.excluding`

Add a basic token counting bin script for counting GPT-4 tokens (`npx langxlang count gpt4 file.txt`)