### PR TITLE
Refactor API to split models by author, refactor handling of function calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,10 +7,12 @@ LangXLang (LXL) is a Node.js library and toolkit for using large language models
 
 LXL supports function calling, caching, prompt templating role play, and building complex conversational flows with LLMs.
 
-Supported models are:
-* OpenAI: `gpt-3.5-turbo-16k`, `gpt-3.5-turbo`, `gpt-4`, `gpt-4-turbo-preview` (or any specific gpt- model listed [here](https://platform.openai.com/docs/models/))
-* Google Gemini: `gemini-1.0-pro` or `gemini-1.5-pro-latest`
-* Google Legacy PaLM2: `text-bison-001`, `text-bison-002`, `palm-2`
+Supports models from OpenAI and those that expose OpenAI-compatible APIs, as well as Google's Gemini models.
+
+Some supported models include:
+* OpenAI: `gpt-4o`, `gpt-4`, `gpt-3.5-turbo`,  (or any specific gpt- model listed [here](https://platform.openai.com/docs/models/))
+* Google Gemini: `gemini-1.5-pro-latest`, `gemini-1.0-pro` 
+<!-- * Google Legacy PaLM2: `text-bison-001`, `text-bison-002`, `palm-2` -->
 
 ## Installation
 ```coffee
@@ -30,6 +32,7 @@ const { ChatSession, CompletionService } = require('langxlang')
 ```js
 const service = new CompletionService({ openai: [key], gemini: [key] })
 const [response] = await service.requestCompletion(
+  'google',                 //  Model author
   'gemini-1.0-pro',         //  Model name
   '',                       //  System prompt (optional)
   'Tell me about yourself'  //  User prompt
@@ -43,7 +46,7 @@ Start a conversation and listen to the response in chunks, streamed to the termi
 
 ```js
 const { ChatSession } = require('langxlang')
-const session = new ChatSession(service, 'gpt-3.5-turbo-16k', /* empty system prompt */ '')
+const session = new ChatSession(service, 'openai', 'gpt-3.5-turbo-16k', /* empty system prompt */ '')
 const q = 'Why is the sky blue?'
 console.log('User:', q)
 await session.sendMessage(q, ({ content }) => { process.stdout.write(content) })
@@ -59,14 +62,15 @@ This is an example to provide a `getTime()` method to the LLM, which can be call
 Note: Each of the functions must have a call to Desc() at the top, to provide a description of the function to the model. If parameters are used, they must be defined with Arg() to provide details to the model, see the example [here](./examples/functions.js) and the TypeScript types [here](./src/index.d.ts) for more details.
 
 ```js
-const { Func: { Arg, Desc } } = require('langxlang')
-const session = new ChatSession(service, 'gpt-3.5-turbo-16k', /* empty system prompt */ '', {
-  functions: {
-    getTime () {
-      Desc('Get the current time')
-      return new Date().toLocaleTimeString()
-    }
-  }
+const { ChatSession } = require('langxlang')
+
+function getTime () {
+  return new Date().toLocaleTimeString()
+}
+getTime.description = 'Get the current time'
+
+const session = new ChatSession(service, 'openai', 'gpt-3.5-turbo-16k', /* empty system prompt */ '', {
+  functions: { getTime }
 })
 session.sendMessage('What time is it?').then(console.log)
 ```
@@ -77,7 +81,7 @@ See a running example in `examples/streaming.js`.
 
 ### CompletionService
 
-#### `constructor(apiKeys: { openai: string, gemini: string })`
+#### `constructor(apiKeys: { openai: string, google: string })`
 
 Creates an instance of completion service.
 Note: as an alternative to explicitly passing the API keys in the constructor you can: 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ const { ChatSession, CompletionService } = require('langxlang')
 *Note: as described below in API section, the keys can be read via the file system to avoid hardcoding them in the code or environment variables. The risk of API key leakage is reduced by reading from the file system, so it's recommended that you use that approach if you can.*
 
 ```js
-const service = new CompletionService({ openai: [key], gemini: [key] })
+const service = new CompletionService({ openai: KEY, gemini: KEY })
 const [response] = await service.requestCompletion(
   'google',                 //  Model author
   'gemini-1.0-pro',         //  Model name

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -38,7 +38,7 @@ const commands = {
       console.log('Tokens:', countTokens(text).toLocaleString())
     } else if (tokenizer === 'gemini1.5pro' || tokenizer === 'g15pro') {
       const service = new CompletionService()
-      service.countTokens('gemini-1.5-pro-latest', text).then((tokens) => {
+      service.countTokens('google', 'gemini-1.5-pro-latest', text).then((tokens) => {
         console.log('Tokens:', tokens.toLocaleString())
       })
     } else {

--- a/docs/extras.md
+++ b/docs/extras.md
@@ -20,7 +20,7 @@ Here is an example:
 ```js
 const { CompletionService } = require('langxlang')
 const service = new CompletionService()
-const [response] = await service.requestChatCompletion('gemini-1.0-pro', {
+const [response] = await service.requestChatCompletion('google', 'gemini-1.0-pro', {
   messages: [
     { role: 'user', message: 'Please convert this YAML to JSON:\n```yml\nhello: world\n```\n' },
     { role: 'guidance', message: '```json\n' }

--- a/examples/functions.js
+++ b/examples/functions.js
@@ -1,4 +1,4 @@
-const { CompletionService, ChatSession, Func: { Arg, Desc } } = require('langxlang')
+const { CompletionService, ChatSession } = require('langxlang')
 
 // Note: you can either define an object here with the keys 'openai' and 'gemini' or you can set the OPENAI_API_KEY and GEMINI_API_KEY environment variables
 // const service = new CompletionService({ openai: 'YOUR OPENAI API' })
@@ -6,27 +6,31 @@ const { CompletionService, ChatSession, Func: { Arg, Desc } } = require('langxla
 const service = new CompletionService()
 console.log('Using cache in', service.cachePath)
 
+const author = 'openai'
 const model = 'gpt-3.5-turbo-16k'
 // const model = 'gemini-1.0-pro'
 
-// All functions must have a Desc() call at the beginning to describe the function.
+// This function returns the current time in UTC. It takes no arguments.
 function getTimeUTC () {
-  Desc('This method returns the current time in UTC')
-  console.log('Getting time with', arguments.length, 'arguments')
+  console.log('api: Getting time with', arguments.length, 'arguments')
   return new Date().toUTCString()
 }
+getTimeUTC.description = 'This method returns the current time in UTC'
 
-// All arguments must be assigned to Arg(), so LXL can parse the function signature and extract the arg data.
-// The Arg() takes in a JSON schema, with the addition of a `default` field that you can use to mark an optional parameter.
-// `description` is a required field on all Arg() calls.
-function getSum (numbers = Arg({ type: 'array', items: { type: 'number' }, description: 'An array of numbers' })) {
-  Desc('This method returns the sum of the numbers')
+// This function returns the sum of the numbers in the array. The input arg is an object
+// for which the schema is defined in the 'parameters' property below.
+function getSum ({ numbers }) {
   console.log('Getting sum with', arguments)
   return numbers.reduce((a, b) => a + b, 0)
 }
+// JSON Schema for the function parameters
+getSum.description = 'This method returns the sum of the numbers'
+getSum.parameters = {
+  numbers: { type: 'array', items: { type: 'number' }, description: 'An array of numbers' }
+}
 
 async function main () {
-  const session = new ChatSession(service, model, '', {
+  const session = new ChatSession(service, author, model, '', {
     functions: { getTimeUTC, getSum }
   })
   const q = 'What time is it right now?'

--- a/examples/old_gemini1.5.js
+++ b/examples/old_gemini1.5.js
@@ -19,7 +19,7 @@ async function testCompletion () {
 async function testChatSession () {
   const service = new GoogleAIStudioCompletionService(8095)
   await service.ready
-  const session = new ChatSession(service, 'gemini-1.5-pro', '')
+  const session = new ChatSession(service, 'google', 'gemini-1.5-pro', '')
   const message = await session.sendMessage('Hello! Why is the sky blue?')
   console.log('Done', message.length, 'bytes', 'now asking a followup')
   // ask related question about the response

--- a/examples/streaming.js
+++ b/examples/streaming.js
@@ -7,10 +7,12 @@ const service = new CompletionService()
 console.log('Using cache in', service.cachePath)
 
 async function main () {
-  const session = new ChatSession(service, 'gpt-3.5-turbo-16k', /* system prompt */ 'Talk like a pirate')
+  const session = new ChatSession(service, 'openai', 'gpt-3.5-turbo-16k', /* system prompt */ 'Talk like a pirate')
+
   const q = 'Why is the sky blue?'
   console.log('User:', q)
   await session.sendMessage(q, ({ content }) => { process.stdout.write(content) })
+
   const q2 = 'What about on the poles?'
   console.log('User:', q2)
   await session.sendMessage(q2, ({ content }) => { process.stdout.write(content) })

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "standard": "^17.0.0"
   },
   "dependencies": {
-    "@google/generative-ai": "^0.9.0",
+    "@google/generative-ai": "^0.21.0",
     "acorn": "^8.11.3",
     "caller": "^1.1.0",
     "debug": "^4.3.4",

--- a/src/ChatSession.js
+++ b/src/ChatSession.js
@@ -60,7 +60,6 @@ class ChatSession {
   }
 
   async _callFunctionWithArgs (functionName, payload) {
-    console.log('Calling function', functionName, 'with', payload)
     const fn = this.functions[functionName]
     const result = await fn(payload)
     return result

--- a/src/CompleteServices.js
+++ b/src/CompleteServices.js
@@ -1,0 +1,285 @@
+const openai = require('./backends/openai')
+// const palm2 = require('./backends/palm2')
+const gemini = require('./backends/gemini')
+const debug = require('debug')('lxl')
+
+const { checkDoesGoogleModelSupportInstructions, checkGuidance } = require('./util')
+
+class BaseCompleteService {
+  constructor (apiKey) {
+    this.apiKey = apiKey
+  }
+
+  ok () {
+    return !!this.apiKey
+  }
+}
+
+class GeminiCompleteService extends BaseCompleteService {
+  constructor (apiKey) {
+    super(apiKey || process.env.GEMINI_API_KEY)
+  }
+
+  async requestCompletion (model, text, options, chunkCb) {
+    // TODO: add support for proper code/text completion models
+    const messages = [{ role: 'user', text: 'Please complete this text:\n' + text }]
+    return this.requestChatComplete(model, messages, options, undefined, chunkCb)
+  }
+
+  async listModels () {
+    return gemini.listModels(this.apiKey)
+  }
+
+  async _processGeminiMessages (model, messages) {
+    debug('gemini.processMessages', JSON.stringify(messages))
+
+    // Google Gemini doesn't support data URLs, or even remote ones, so we need to fetch them, extract data URLs then split
+    async function resolveImage (url) {
+      // fetch the URL contents to a data URL (node.js)
+      const req = await fetch(url)
+      const buffer = await req.arrayBuffer()
+      const dataURL = `data:${req.headers.get('content-type')};base64,${Buffer.from(buffer).toString('base64')}`
+      return dataURL
+    }
+
+    function splitDataURL (entry) {
+      // gemini doesn't support data URLs
+      const mimeType = entry.slice(5, entry.indexOf(';'))
+      const data = entry.slice(entry.indexOf(',') + 1)
+      return { inlineData: { mimeType, data } }
+    }
+
+    // April 2024 - Only Gemini 1.5 supports instructions
+    const supportsSystemInstruction = checkDoesGoogleModelSupportInstructions(model)
+    const imagesForResolve = []
+    const geminiMessages = messages.map((msg) => {
+      const m = structuredClone(msg)
+      if (msg.role === 'assistant') m.role = 'model'
+      if (msg.role === 'system') m.role = supportsSystemInstruction ? 'system' : 'user'
+      if (msg.role === 'guidance') m.role = 'model'
+      if (msg.role === 'function') {
+        const [part] = msg.parts
+        m.parts = [{
+          functionResponse: {
+            name: part.functionResponse.name,
+            response: {
+              name: part.functionResponse.name,
+              content: part.functionResponse.response
+            }
+          }
+        }]
+        return m
+      }
+      if (msg.text) {
+        m.parts = [{ text: msg.text }]
+        delete m.text
+        return m
+      }
+      if (typeof msg.parts === 'object') {
+        const updated = []
+        for (const entry of msg.parts) {
+          if (entry.text) {
+            updated.push({ text: entry.text })
+          } else if (entry.imageURL) {
+            const val = { imageURL: entry.imageURL }
+            imagesForResolve.push(val)
+            updated.push(val)
+          } else if (entry.imageB64Url) {
+            updated.push(splitDataURL(entry.imageB64Url))
+          } else if (entry.mimeType) {
+            const dataAsB64 = Buffer.from(entry.data).toString('base64')
+            updated.push({ inlineData: { mimeType: entry.mimeType, data: dataAsB64 } })
+          } else if (entry.functionCall) {
+            updated.push({ functionCall: { name: entry.functionCall.name, args: entry.functionCall.args } })
+          }
+        }
+      } else {
+        throw new Error('Message .parts should be an array of part objects')
+      }
+      return m
+    }).filter((msg) => msg.parts && (msg.parts.length > 0))
+
+    for (const entry of imagesForResolve) {
+      const dataURL = await resolveImage(entry.imageURL)
+      Object.assign(entry, splitDataURL(dataURL))
+      delete entry.imageURL
+    }
+
+    return geminiMessages
+  }
+
+  async requestChatComplete (model, messages, { maxTokens, stopSequences, temperature, topP, topK }, functions, chunkCb) {
+    if (!this.apiKey) throw new Error('Gemini API key not set')
+    const guidance = checkGuidance(messages, chunkCb)
+    const geminiMessages = await this._processGeminiMessages(model, messages)
+
+    const response = await gemini.generateChatCompletionEx(model, geminiMessages, {
+      apiKey: this.apiKey,
+      functions,
+      generationConfig: {
+        maxOutputTokens: maxTokens,
+        stopSequences,
+        temperature,
+        topP,
+        topK
+      }
+    }, chunkCb)
+    console.log('Response:')
+    console.dir(response, { depth: null })
+    if (response.text()) {
+      const answer = response.text()
+      console.log('is a text response', answer, !!response.text())
+      chunkCb?.({ done: true, delta: '' })
+      const content = guidance ? guidance + answer : answer
+      const result = {
+        type: 'text',
+        isTruncated: response.finishReason === 'MAX_TOKENS',
+        parts: [{ text: content }],
+        safetyRatings: response.safetyRatings,
+        text: content
+      }
+      return [result]
+    } else if (response.functionCalls()) {
+      const calls = response.functionCalls()
+      console.log('is a FnCall')
+      const fnCalls = {}
+      for (let i = 0; i < calls.length; i++) {
+        const call = calls[i]
+        fnCalls[i] = {
+          id: i,
+          name: call.name,
+          args: call.args
+        }
+      }
+      const result = {
+        type: 'function',
+        fnCalls,
+        // TODO: map the content parts here to LXL's format
+        parts: response.parts,
+        safetyRatings: response.safetyRatings
+      }
+      return [result]
+    } else {
+      console.log('Text:', response.text(), 'Function calls:', response.functionCalls())
+      throw new Error('Unknown response from Gemini')
+    }
+  }
+
+  async countTokens (model, content) {
+    let parts = content
+    if (!Array.isArray(content)) {
+      const [a] = await this._processGeminiMessages(model, [{ role: 'user', content }])
+      parts = a.parts
+    }
+    return gemini.countTokens(this.apiKey, model, parts)
+  }
+
+  async countTokensInMessages (model, messages) {
+    return gemini.countTokens(this.geminiApiKey, model, this._processGeminiMessages(model, messages))
+  }
+}
+
+class OpenAICompleteService extends BaseCompleteService {
+  constructor (apiKey) {
+    super(apiKey || process.env.OPENAI_API_KEY)
+  }
+
+  async requestCompletion (model, text, options, chunkCb) {
+    const messages = [{ role: 'user', text: 'Please complete the following text:\n' + text }]
+    return this.requestChatComplete(model, messages, options, undefined, chunkCb)
+  }
+
+  async requestChatComplete (model, messages, { maxTokens, stopSequences, temperature, topP }, functions, chunkCb) {
+    if (!this.apiKey) throw new Error('OpenAI API key not set')
+    const guidance = checkGuidance(messages, chunkCb)
+    const response = await openai.generateChatCompletionIn(
+      model,
+      messages.map((entry) => {
+        const msg = structuredClone(entry)
+        if (msg.role === 'model') msg.role = 'assistant'
+        if (msg.role === 'guidance') msg.role = 'assistant'
+        if (msg.role === 'function') {
+          const [part] = msg.parts
+          msg.content = part.functionResponse.response
+          delete msg.parts
+          return msg
+        }
+        if (msg.text != null) {
+          delete msg.text
+          msg.content = entry.text
+        }
+        if (typeof msg.parts === 'object') {
+          const updated = []
+          for (const key in msg.parts) {
+            const value = msg.parts[key]
+            if (value.text) {
+              updated.push({ type: 'text', text: value.text })
+            } else if (value.imageURL) {
+              updated.push({ type: 'image_url', image_url: { url: value.imageURL, detail: value.imageDetail } })
+            } else if (value.imageB64Url) {
+              const dataURL = value.imageB64Url
+              updated.push({ type: 'image_url', image_url: { url: dataURL, detail: value.imageDetail } })
+            } else if (value.data) {
+              if (!value.mimeType) throw new Error('Missing mimeType for inline data')
+              updated.push({ type: 'image_url', image_url: { url: `data:${value.mimeType};base64,${value.data}`, detail: value.imageDetail } })
+            } else if (value.functionCall) {
+              msg.function_call = { name: value.functionCall.name, arguments: JSON.stringify(value.functionCall.args) }
+            }
+          }
+          msg.content = updated
+        }
+        return msg
+      }).filter((msg) => msg.content),
+      {
+        apiKey: this.apiKey,
+        functions,
+        generationConfig: {
+          max_tokens: maxTokens,
+          stop: stopSequences,
+          temperature,
+          top_p: topP
+        }
+      },
+      chunkCb
+    )
+    return response.choices.map((choice) => {
+      const choiceType = {
+        stop: 'text',
+        length: 'text',
+        function_call: 'function',
+        content_filter: 'safety', // an error would be thrown before this
+        tool_calls: 'function'
+      }[choice.finishReason] ?? 'unknown'
+      const content = guidance ? guidance + choice.content : choice.content
+      // assert that the content is a string as OpenAI can't interleave image and
+      // text content yet... and we don't know how it'd look like outputwise if it did
+      if (typeof content !== 'string') throw new Error('Expected content to be a string')
+      const parts = [{ text: content }]
+      return {
+        type: choiceType,
+        isTruncated: choice.finishReason === 'length',
+        fnCalls: choice.fnCalls,
+        parts,
+        text: content
+      }
+    })
+  }
+
+  async listModels () {
+    const list = await openai.listModels(this.apiKey)
+    return Object.fromEntries(list.map((e) => ([e.id, e])))
+  }
+
+  async countTokens (model, content) {
+    // return openai.countTokens(this.apiKey, model, content)
+    return require('./tools/tokens').countTokens('gpt-4', content)
+  }
+
+  async countTokensInMessages (model, messages) {
+    return messages.reduce((cumLen, entry) => {
+      return cumLen + this.countTokens(model, entry.content)
+    }, 0)
+  }
+}
+
+module.exports = { OpenAICompleteService, GeminiCompleteService }

--- a/src/CompleteServices.js
+++ b/src/CompleteServices.js
@@ -164,7 +164,7 @@ class GeminiCompleteService extends BaseCompleteService {
   async countTokens (model, content) {
     let parts = content
     if (!Array.isArray(content)) {
-      const [a] = await this._processGeminiMessages(model, [{ role: 'user', content }])
+      const [a] = await this._processGeminiMessages(model, [{ role: 'user', text: content }])
       parts = a.parts
     }
     return gemini.countTokens(this.apiKey, model, parts)
@@ -176,8 +176,9 @@ class GeminiCompleteService extends BaseCompleteService {
 }
 
 class OpenAICompleteService extends BaseCompleteService {
-  constructor (apiKey) {
+  constructor (apiKey, apiBase) {
     super(apiKey || process.env.OPENAI_API_KEY)
+    this.apiBase = apiBase || process.env.OPENAI_API_BASE
   }
 
   async requestCompletion (model, text, options, chunkCb) {
@@ -232,6 +233,7 @@ class OpenAICompleteService extends BaseCompleteService {
         return msg
       }).filter((msg) => msg.content),
       {
+        baseURL: this.apiBase,
         apiKey: this.apiKey,
         functions,
         generationConfig: {
@@ -267,7 +269,7 @@ class OpenAICompleteService extends BaseCompleteService {
   }
 
   async listModels () {
-    const list = await openai.listModels(this.apiKey)
+    const list = await openai.listModels(this.apiBase, this.apiKey)
     return Object.fromEntries(list.map((e) => ([e.id, e])))
   }
 

--- a/src/CompletionService.js
+++ b/src/CompletionService.js
@@ -81,7 +81,7 @@ class CompletionService {
       return responses
     }
 
-    const ret = await service.requestCompletion(author, model, text, chunkCb, genOpts)
+    const ret = await service.requestCompletion(model, text, genOpts, chunkCb)
     return saveIfCaching(ret)
   }
 

--- a/src/CompletionService.js
+++ b/src/CompletionService.js
@@ -20,6 +20,10 @@ class CompletionService {
       openai: new OpenAICompleteService(keys.openai),
       google: new GeminiCompleteService(keys.gemini)
     }
+    if (options.apiBase) {
+      // Override the default API base URL, useful for ollama and other OpenAI-compatible APIs
+      this.servicesByAuthor.openai.apiBase = options.apiBase
+    }
     this.services = Object.values(this.servicesByAuthor)
     this.defaultGenerationOptions = options.generationOptions
   }

--- a/src/CompletionService.js
+++ b/src/CompletionService.js
@@ -1,9 +1,12 @@
-const openai = require('./backends/openai')
-const palm2 = require('./backends/palm2')
-const gemini = require('./backends/gemini')
-const { cleanMessage, getModelInfo, checkDoesGoogleModelSupportInstructions, checkGuidance, knownModels } = require('./util')
+const { cleanMessage } = require('./util')
 const caching = require('./caching')
 const logging = require('./tools/logging')
+
+const { OpenAICompleteService, GeminiCompleteService } = require('./CompleteServices')
+
+function assert (condition, message = 'Assertion failed') {
+  if (!condition) throw new Error(message)
+}
 
 class CompletionService {
   constructor (keys, options = {}) {
@@ -13,10 +16,11 @@ class CompletionService {
       this.cachePath = cache.path
     }
     this.options = options
-    this.palm2ApiKey = keys.palm2 || process.env.PALM2_API_KEY
-    this.geminiApiKey = keys.gemini || process.env.GEMINI_API_KEY
-    this.openaiApiKey = keys.openai || process.env.OPENAI_API_KEY
-
+    this.servicesByAuthor = {
+      openai: new OpenAICompleteService(keys.openai),
+      google: new GeminiCompleteService(keys.gemini)
+    }
+    this.services = Object.values(this.servicesByAuthor)
     this.defaultGenerationOptions = options.generationOptions
   }
 
@@ -33,39 +37,30 @@ class CompletionService {
   }
 
   async listModels () {
-    const openaiModels = {}
-    const geminiModels = {}
-    if (this.openaiApiKey) {
-      const openaiList = await openai.listModels(this.openaiApiKey)
-      Object.assign(openaiModels, Object.fromEntries(openaiList.map((e) => ([e.id, e]))))
+    const modelsByAuthor = {}
+    for (const author in this.servicesByAuthor) {
+      const service = this.servicesByAuthor[author]
+      if (service.ok()) {
+        modelsByAuthor[author] = await service.listModels()
+      }
     }
-    if (this.geminiApiKey) {
-      const geminiList = await gemini.listModels(this.geminiApiKey)
-      Object.assign(geminiModels, Object.fromEntries(geminiList
-        .filter((e) => e.name.startsWith('models/'))
-        .map((e) => ([e.name.replace('models/', ''), e]))))
-    }
-    return { openai: openaiModels, google: geminiModels }
+    return modelsByAuthor
   }
 
-  async _requestCompletionOpenAI (model, system, user, options, chunkCb) {
-    const messages = [{ role: 'user', content: user }]
-    if (system) messages.unshift({ role: 'system', content: system })
-    return this._requestChatCompleteOpenAI(model, messages, options, undefined, chunkCb)
+  _getService (author) {
+    const service = this.servicesByAuthor[author]
+    if (!service) throw new Error(`No such model family: ${author}`)
+    if (!service.ok()) throw new Error(`No API key for ${author}`)
+    return service
   }
 
-  async _requestCompletionGemini (model, system, user, options, chunkCb) {
-    const messages = [{ role: 'user', content: user }]
-    if (system) messages.unshift({ role: 'system', content: system })
-    return this._requestChatCompleteGemini(model, messages, options, undefined, chunkCb)
-  }
+  async requestCompletion (author, model, text, chunkCb, options = {}) {
+    const service = this._getService(author)
 
-  async requestCompletion (model, system, user, chunkCb, options = {}) {
-    system = cleanMessage(system)
-    user = cleanMessage(user)
+    text = cleanMessage(text)
 
     if (options.enableCaching) {
-      const cachedResponse = await caching.getCachedResponse(model, [system, user])
+      const cachedResponse = await caching.getCachedResponse(model, ['', text])
       if (cachedResponse) {
         chunkCb?.({ done: false, content: cachedResponse.text })
         chunkCb?.({ done: true, delta: '' })
@@ -78,207 +73,31 @@ class CompletionService {
       enableCaching: false // already handle caching here, as some models alias to chat we don't want to cache twice.
     }
     const saveIfCaching = (responses) => {
-      this.log?.push(structuredClone({ model, system, user, responses, generationOptions: genOpts, date: new Date() }))
+      this.log?.push(structuredClone({ author, model, system: '', user: text, responses, generationOptions: genOpts, date: new Date() }))
       const [response] = responses
       if (response && response.content && options.enableCaching) {
-        caching.addResponseToCache(model, [system, user], response)
+        caching.addResponseToCache(model, ['', text], response)
       }
       return responses
     }
 
-    const { family } = getModelInfo(model)
-    switch (family) {
-      case 'openai': return saveIfCaching(await this._requestCompletionOpenAI(model, system, user, genOpts))
-      case 'gemini': return saveIfCaching(await this._requestCompletionGemini(model, system, user, genOpts, chunkCb))
-      case 'palm2': {
-        if (!this.palm2ApiKey) throw new Error('PaLM2 API key not set')
-        const result = await palm2.requestPalmCompletion(system + '\n' + user, this.palm2ApiKey, model)
-        return saveIfCaching({ text: result, content: result })
-      }
-      default:
-        throw new Error(`Model '${model}' not supported for completion, available models: ${knownModels.join(', ')}`)
-    }
+    const ret = await service.requestCompletion(author, model, text, chunkCb, genOpts)
+    return saveIfCaching(ret)
   }
 
-  async _requestChatCompleteOpenAI (model, messages, { maxTokens, stopSequences, temperature, topP }, functions, chunkCb) {
-    if (!this.openaiApiKey) throw new Error('OpenAI API key not set')
-    const guidance = checkGuidance(messages, chunkCb)
-    const response = await openai.generateChatCompletionIn(
-      model,
-      messages.map((entry) => {
-        const msg = structuredClone(entry)
-        if (msg.role === 'model') msg.role = 'assistant'
-        if (msg.role === 'guidance') msg.role = 'assistant'
-        if (msg.text != null) {
-          delete msg.text
-          msg.content = entry.text
-        }
-        if (typeof msg.content === 'object') {
-          const updated = []
-          for (const key in msg.content) {
-            const value = msg.content[key]
-            if (value.text) {
-              updated.push({ type: 'text', text: value.text })
-            } else if (value.imageURL) {
-              updated.push({ type: 'image_url', image_url: { url: value.imageURL, detail: value.imageDetail } })
-            } else if (value.imageB64) {
-              let dataURL = value.imageB64
-              if (!dataURL.startsWith('data:')) {
-                if (!value.mimeType) throw new Error('Missing accompanying `mimeType` for imageB64 that is not a data URL')
-                dataURL = `data:${value.mimeType};base64,${dataURL}`
-              }
-              updated.push({ type: 'image_url', image_url: { url: dataURL, detail: value.imageDetail } })
-            } else if (value.image_url) {
-              updated.push({ type: 'image_url', image_url: value.image_url })
-            }
-          }
-          msg.content = updated
-        }
-        return msg
-      }).filter((msg) => msg.content),
-      {
-        apiKey: this.openaiApiKey,
-        functions,
-        generationConfig: {
-          max_tokens: maxTokens,
-          stop: stopSequences,
-          temperature,
-          top_p: topP
-        }
-      },
-      chunkCb
-    )
-    return response.choices.map((choice) => {
-      const choiceType = {
-        stop: 'text',
-        length: 'text',
-        function_call: 'function',
-        content_filter: 'safety', // an error would be thrown before this
-        tool_calls: 'function'
-      }[choice.finishReason] ?? 'unknown'
-      const content = guidance ? guidance + choice.content : choice.content
-      return {
-        type: choiceType,
-        isTruncated: choice.finishReason === 'length',
-        // ...choice,
-        content,
-        text: content
-      }
-    })
-  }
+  async requestChatCompletion (author, model, { messages, functions, enableCaching, generationOptions }, chunkCb) {
+    const service = this._getService(author)
 
-  async _processGeminiMessages (model, messages) {
-    // Google Gemini doesn't support data URLs, or even remote ones, so we need to fetch them, extract data URLs then split
-    async function resolveImage (url) {
-      // fetch the URL contents to a data URL (node.js)
-      const req = await fetch(url)
-      const buffer = await req.arrayBuffer()
-      const dataURL = `data:${req.headers.get('content-type')};base64,${Buffer.from(buffer).toString('base64')}`
-      return dataURL
+    // Ensure that `functions` if specified, is { name, description, parameters }[]
+    if (functions) {
+      assert(Array.isArray(functions), 'functions must be an array')
+      for (const fn of functions) {
+        assert(typeof fn.name === 'string', 'functions must have a name')
+        assert(typeof fn.description === 'string', 'functions must have a description')
+        if (fn.parameters) assert(!Array.isArray(fn.parameters), 'parameters must be a JSON Schema object')
+      }
     }
 
-    function splitDataURL (entry) {
-      // gemini doesn't support data URLs
-      const mimeType = entry.slice(5, entry.indexOf(';'))
-      const data = entry.slice(entry.indexOf(',') + 1)
-      return { inlineData: { mimeType, data } }
-    }
-
-    // April 2024 - Only Gemini 1.5 supports instructions
-    const supportsSystemInstruction = checkDoesGoogleModelSupportInstructions(model)
-    const imagesForResolve = []
-    const geminiMessages = messages.map((msg) => {
-      const m = structuredClone(msg)
-      if (msg.role === 'assistant') m.role = 'model'
-      if (msg.role === 'system') m.role = supportsSystemInstruction ? 'system' : 'user'
-      if (msg.role === 'guidance') m.role = 'model'
-      if (typeof msg.content === 'object') {
-        const updated = []
-        for (const entry of msg.content) {
-          if (entry.text) {
-            updated.push({ text: entry.text })
-          } else if (entry.imageURL) {
-            const val = { imageURL: entry.imageURL }
-            imagesForResolve.push(val)
-            updated.push(val)
-          } else if (entry.imageB64) {
-            if (entry.imageB64.startsWith('data:')) {
-              updated.push(splitDataURL(entry.imageB64))
-            } else if (entry.mimeType) {
-              updated.push({
-                inlineData: {
-                  mimeType: entry.mimeType,
-                  data: entry.imageB64
-                }
-              })
-            }
-          }
-        }
-        delete m.content
-        m.parts = updated
-      } else if (msg.content != null) {
-        delete m.content
-        m.parts = [{ text: msg.content }]
-      }
-      return m
-    }).filter((msg) => msg.parts && (msg.parts.length > 0))
-
-    for (const entry of imagesForResolve) {
-      const dataURL = await resolveImage(entry.imageURL)
-      Object.assign(entry, splitDataURL(dataURL))
-      delete entry.imageURL
-    }
-
-    return geminiMessages
-  }
-
-  async _requestChatCompleteGemini (model, messages, { maxTokens, stopSequences, temperature, topP, topK }, functions, chunkCb) {
-    if (!this.geminiApiKey) throw new Error('Gemini API key not set')
-    const guidance = checkGuidance(messages, chunkCb)
-    const geminiMessages = await this._processGeminiMessages(model, messages)
-
-    const response = await gemini.generateChatCompletionEx(model, geminiMessages, {
-      apiKey: this.geminiApiKey,
-      functions,
-      generationConfig: {
-        maxOutputTokens: maxTokens,
-        stopSequences,
-        temperature,
-        topP,
-        topK
-      }
-    }, chunkCb)
-    if (response.text()) {
-      const answer = response.text()
-      chunkCb?.({ done: true, delta: '' })
-      const content = guidance ? guidance + answer : answer
-      const result = {
-        type: 'text',
-        isTruncated: response.finishReason === 'MAX_TOKENS',
-        content,
-        safetyRatings: response.safetyRatings,
-        text: content
-      }
-      return [result]
-    } else if (response.functionCalls()) {
-      const calls = response.functionCalls()
-      const fnCalls = {}
-      for (let i = 0; i < calls.length; i++) {
-        const call = calls[i]
-        fnCalls[i] = {
-          id: i,
-          name: call.name,
-          args: call.args
-        }
-      }
-      const result = { type: 'function', fnCalls, safetyRatings: response.safetyRatings }
-      return [result]
-    } else {
-      throw new Error('Unknown response from Gemini')
-    }
-  }
-
-  async requestChatCompletion (model, { messages, functions, enableCaching, generationOptions }, chunkCb) {
     if (enableCaching) {
       const cachedResponse = await caching.getCachedResponse(model, messages)
       if (cachedResponse) {
@@ -288,7 +107,7 @@ class CompletionService {
       }
     }
     const saveIfCaching = (responses) => {
-      this.log?.push(structuredClone({ model, messages, responses, generationOptions, date: new Date() }))
+      this.log?.push(structuredClone({ author, model, messages, responses, generationOptions, date: new Date() }))
       const [response] = responses
       if (response && response.content && enableCaching) {
         caching.addResponseToCache(model, messages, response)
@@ -296,47 +115,22 @@ class CompletionService {
       return responses
     }
 
-    const { family } = getModelInfo(model)
-    switch (family) {
-      case 'openai':
-        return saveIfCaching(await this._requestChatCompleteOpenAI(model, messages, { ...this.defaultGenerationOptions, ...generationOptions }, functions, chunkCb))
-      case 'gemini':
-        return saveIfCaching(await this._requestChatCompleteGemini(model, messages, { ...this.defaultGenerationOptions, ...generationOptions }, functions, chunkCb))
-      default:
-        throw new Error(`Model '${model}' not supported for streaming chat, available models: ${knownModels.join(', ')}`)
-    }
+    const ret = await service.requestChatComplete(model, messages, { ...this.defaultGenerationOptions, ...generationOptions }, functions, chunkCb)
+    return saveIfCaching(ret)
   }
 
-  async countTokens (model, content) {
-    const { family } = getModelInfo(model)
-    switch (family) {
-      case 'openai':
-        return require('./tools/tokens').countTokens('gpt-4', content)
-      case 'gemini':
-        return gemini.countTokens(this.geminiApiKey, model, Array.isArray(content)
-          ? (await this._processGeminiMessages(model, [{ role: 'user', content }]))[0].parts
-          : content)
-      default:
-        throw new Error(`Model '${model}' not supported for token counting, available models: ${knownModels.join(', ')}`)
-    }
+  async countTokens (author, model, content) {
+    const service = this._getService(author)
+    return service.countTokens(model, content)
   }
 
-  async countTokensInMessages (model, messages) {
-    const { family } = getModelInfo(model)
-    switch (family) {
-      case 'openai':
-        return messages.reduce((cumLen, entry) => {
-          return cumLen + this.countTokens(model, entry.content)
-        }, 0)
-      case 'gemini':
-        return gemini.countTokens(this.geminiApiKey, model, this._processGeminiMessages(model, messages))
-      default:
-        throw new Error(`Model '${model}' not supported for token counting, available models: ${knownModels.join(', ')}`)
-    }
+  async countTokensInMessages (author, model, messages) {
+    const service = this._getService(author)
+    return service.countTokensInMessages(model, messages)
   }
 
-  stop () {}
-  close () {}
+  stop () { }
+  close () { }
 }
 
 module.exports = { appDataDir: caching.appDataDir, CompletionService }

--- a/src/Flow.js
+++ b/src/Flow.js
@@ -7,7 +7,7 @@ class Flow {
     this.service = service
     this.rootFlow = rootFlow
     this.chunkCb = options.chunkCb
-    this.defaultModel = options.model || 'gemini-1.5-pro'
+    this.defaultModel = { author: 'google', name: options.model || 'gemini-1.5-pro' }
     this.generationOpts = options.generation
   }
 
@@ -37,11 +37,15 @@ class Flow {
     } else {
       if (prompt.system) {
         const system = tools.loadPrompt(prompt.system, usingVars)
-        messages.push({ role: 'system', content: system })
+        const text = Array.isArray(system) ? null : system
+        const parts = Array.isArray(system) ? system : null
+        messages.push({ role: 'system', text, parts })
       }
       if (prompt.user) {
         const user = tools.loadPrompt(prompt.user, usingVars)
-        messages.push({ role: 'user', content: user })
+        const text = Array.isArray(user) ? null : user
+        const parts = Array.isArray(user) ? user : null
+        messages.push({ role: 'user', text, parts })
       }
     }
 
@@ -51,7 +55,7 @@ class Flow {
     if (runFollowUp && runFollowUp.pastResponses[inputHash]) {
       resp = structuredClone(runFollowUp.pastResponses[inputHash])
     } else {
-      const rs = await this.service.requestChatCompletion(model, { messages, generationOptions: this.generationOpts }, this.chunkCb)
+      const rs = await this.service.requestChatCompletion(model.author, model.name, { messages, generationOptions: this.generationOpts }, this.chunkCb)
       resp = rs[0]
     }
     if (!resp) {

--- a/src/backends/gemini.js
+++ b/src/backends/gemini.js
@@ -20,6 +20,7 @@ async function waitForRateLimit (apiKey, model, customRateLimit) {
 }
 
 async function generateChatCompletionEx (model, messages, options, chunkCb) {
+  debug('gemini.generateChatCompletion', JSON.stringify(options))
   await waitForRateLimit(options.apiKey, model, options.rateLimit)
   const google = new GoogleGenerativeAI(options.apiKey)
   const generator = google.getGenerativeModel({ model }, { apiVersion: 'v1beta' })
@@ -41,18 +42,59 @@ async function generateChatCompletionEx (model, messages, options, chunkCb) {
         }
       : undefined
   }
-  if (options.functions) {
+  if (options.functions) { // { name, description, parameters }[]
     payload.tools.push({ functionDeclarations: options.functions })
   }
-  debug('Sending Gemini payload', JSON.stringify(payload, null, 2))
   const stream = await generator.generateContentStream(payload)
+  const aggParts = []
   for await (const result of stream.stream) {
-    debug('Chunk', result.text())
-    chunkCb?.({ content: result.text(), done: false, raw: result })
+    debug('gemini.Chunk', JSON.stringify(result))
+    let i = 0
+    for (const candidate of result.candidates) {
+      aggParts.push(...candidate.content.parts)
+      if (!candidate.finishReason || candidate.finishReason === 'STOP') {
+        const text = candidate.content.parts
+          .filter(part => part.text !== '')
+          .reduce((acc, part) => acc + part.text, '')
+        if (candidate.content.functionCalls?.length) {
+          // Function response
+          // TODO: Map the content parts here to LXL's format
+          chunkCb?.({
+            n: i,
+            parts: candidate.content.parts,
+            textDelta: text,
+            done: false,
+            raw: candidate
+          })
+        } else {
+          // Text response
+          // TODO: Map the content parts here to LXL's format
+          chunkCb?.({ n: i, textDelta: text, parts: candidate.content.parts, done: false, raw: candidate })
+        }
+      } else if (candidate.finishReason === 'SAFETY') {
+        throw new SafetyError(`Gemini completion candidate ${i} was blocked by safety filter: ${JSON.stringify(candidate.safetyRatings)}`)
+      } else {
+        throw new Error(`Gemini completion candidate ${i} failed with reason: ${candidate.finishReason}`)
+      }
+      i++
+    }
   }
+  chunkCb?.({ done: true })
   const response = await stream.response
-  debug('Gemini Response', [response.text(), response.functionCalls()])
-  return response
+  debug('gemini.Response', [response.text(), response.functionCalls()], JSON.stringify(aggParts))
+  // we can't use the Gemini API's .text() or .functionCalls() here, because they don't work with streaming...
+  const text = aggParts.filter(part => part.text).reduce((acc, part) => acc + part.text, '')
+  const functionCalls = aggParts.filter(part => part.functionCall).map(part => ({
+    name: part.functionCall.name,
+    args: part.functionCall.args
+  }))
+  return {
+    _text: text,
+    _functionCalls: functionCalls,
+    text: () => text,
+    functionCalls: () => functionCalls,
+    parts: aggParts
+  }
 }
 
 // We now use the Google NPM package, but this method is helpful for understanding/debugging. It doesn't support function calling or streaming.

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -97,7 +97,8 @@ declare module 'langxlang' {
   }
 
   // The functions that can be used in the user prompt.
-  type Functions<T extends any[]> = Record<string, (...args: T) => void>
+  type ModelFn = (input: any) => any & { description: string, parameters?: Record<string, { type: any, description?: string, required?: boolean }> }
+  type Functions = Record<string, ModelFn>
 
   class ChatSession<T extends any[]> {
     // ChatSession is for back and forth conversation between a user an an LLM.

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -30,7 +30,7 @@ declare module 'langxlang' {
     // `{"keys": {"openai": "your-openai-key", "gemini": "your-gemini-key"}}`
     // In this options object, you can specify generation options that will be applied by default to
     // all requestCompletion calls. You can override these options by passing them in the requestCompletion call.
-    constructor(apiKeys: { openai: string, gemini: string }, options?: { generationOptions: CompletionOptions })
+    constructor(apiKeys: { openai: string, gemini: string }, options?: { apiBase?: string, generationOptions: CompletionOptions })
 
     cachePath: string
 

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,16 +1,18 @@
 type CompletionResponse = { content: string, text: string }
 
 declare module 'langxlang' {
+  type ModelAuthor = 'google' | 'openai'
   type Model = 'gpt-3.5-turbo-16k' | 'gpt-3.5-turbo' | 'gpt-4' | 'gpt-4-turbo-preview' | 'gemini-1.0-pro' | 'gemini-1.5-pro-latest'
   type Role = 'system' | 'user' | 'assistant' | 'guidance'
-  type MessagePart = 
+  type MessagePart =
     | { text: string }
-    | { imageURL: string, imageDetail? }
-    | { imageB64: string, mimeType?: string, imageDetail? }
-  type Message = 
-    | { role: Role, content: string }
-    | { role: Role, content: MessagePart }
-  type ChunkCb = ({ content: string }) => void
+    | { imageURL: string, imageDetail?}
+    | { imageB64Url: string,  imageDetail?}
+    | { data: Buffer, mimeType?: string, imageDetail? }
+  type Message =
+    | { role: Role, text: string }
+    | { role: Role, parts: MessagePart[] }
+  type ChunkCb = ({ n: number, textDelta: string, parts: MessagePart, done: boolean }) => void
 
   type CompletionOptions = {
     maxTokens?: number
@@ -37,18 +39,18 @@ declare module 'langxlang' {
     // Stop logging LLM requests, return the HTML of the log
     stopLogging(): { exportHTML: () => string }
 
-    listModels(): Promise<{ openai: Record<string, object>, google: Record<string, object> }>
+    listModels(): Promise<{ [typeof ModelAuthor]: Record<Model, /* platform-specific data */ object> }>
 
-    countTokens(model: Model, text: string | MessagePart[]): Promise<number>
-    countTokensInMessages(model: Model, text: string | MessagePart[]): Promise<number>
+    countTokens(author: ModelAuthor, model: Model, text: string | MessagePart[]): Promise<number>
+    countTokensInMessages(author: ModelAuthor, model: Model, text: string | MessagePart[]): Promise<number>
 
     // Request a completion from the model with a system prompt and a single user prompt.
-    requestCompletion(model: Model, systemPrompt: string, userPrompt: string | MessagePart[], _chunkCb?: ChunkCb, options?: CompletionOptions & {
+    requestCompletion(author: ModelAuthor | string, model: Model | string, parts: string | MessagePart[], _chunkCb?: ChunkCb, options?: CompletionOptions & {
       // If true, the response will be cached and returned from the cache if the same request is made again.
       enableCaching?: boolean
     }): Promise<CompletionResponse[]>
     // Request a completion from the model with a sequence of chat messages which have roles.
-    requestChatCompletion(model: Model, options: { messages: Message[], generationOptions?: CompletionOptions }, chunkCb?: ChunkCb): Promise<CompletionResponse[]>
+    requestChatCompletion(author: ModelAuthor | string, model: Model | string, options: { messages: Message[], generationOptions?: CompletionOptions }, chunkCb?: ChunkCb): Promise<CompletionResponse[]>
   }
 
   // Note: GoogleAIStudioCompletionService does NOT use the official AI Studio API, but instead uses a relay server to forward requests to an AIStudio client.
@@ -99,12 +101,14 @@ declare module 'langxlang' {
 
   class ChatSession<T extends any[]> {
     // ChatSession is for back and forth conversation between a user an an LLM.
-    constructor(completionService: SomeCompletionService, model: Model, systemPrompt?: string)
-    constructor(completionService: SomeCompletionService, model: Model, systemPrompt?: string, options?: { functions?: Functions<T>, generationOptions?: CompletionOptions })
+    constructor(completionService: SomeCompletionService, author: ModelAuthor | string, model: Model | string, systemPrompt?: string)
+    constructor(completionService: SomeCompletionService, author: ModelAuthor | string, model: Model | string, systemPrompt?: string, options?: { functions?: Functions<T>, generationOptions?: CompletionOptions })
     // Send a message to the LLM and receive a response as return value. The chunkCallback
     // can be defined to listen to bits of the message stream as it's being written by the LLM.
     sendMessage(userMessage: string | MessagePart[], chunkCallback?: ChunkCb, generationOptions?: CompletionOptions): Promise<string>
   }
+
+  // ============ TOOLS ============
 
   type StripOptions = {
     stripEmailQuotes?: boolean,
@@ -217,8 +221,8 @@ declare module 'langxlang' {
 interface FlowChainObjectBase {
   model: Model
   prompt:
-    | { system: string, user: string }
-    | { text: string, roles: Record<string, Role> }
+  | { system: string, user: string }
+  | { text: string, roles: Record<string, Role> }
   with: Record<string, string>
   followUps: Record<string, (resp: CompletionResponse, input: object) => SomeFlowChainObject>
   // The function that transforms the response from the model before it's passed to the followUps/next or returned

--- a/src/service/server.js
+++ b/src/service/server.js
@@ -49,13 +49,13 @@ async function main (port, services) {
     })
 
     client.receive('chatCompletion', (req, resp) => {
-      const { service, model, messages } = req
+      const { service, author, model, messages } = req
       const completionService = services[service || '']
       if (!completionService) {
         resp.sendResponse({ error: `No service for ${service}` })
         return
       }
-      completionService.requestChatCompletion(model, { messages }, (chunk) => {
+      completionService.requestChatCompletion(author, model, { messages }, (chunk) => {
         resp.sendChunk(chunk)
       })
         .then((result) => {

--- a/src/service/studio/index.html
+++ b/src/service/studio/index.html
@@ -569,7 +569,7 @@
         const DEFAULT_MODEL = 'gemini-1.0-pro'
         const model = playground.models.find(model => model.model === DEFAULT_MODEL)
         console.log('Setting active model', model)
-        const modelValue = JSON.stringify({ service: model.service, model: model.model })
+        const modelValue = JSON.stringify({ service: model.service, author: model.author, model: model.model })
         document.getElementById('model').value = modelValue
         setActiveModel(modelValue)
       })

--- a/src/tools/logging.js
+++ b/src/tools/logging.js
@@ -11,6 +11,7 @@ function createHTML (log) {
     entries.push({
       on: new Date(entry.date).toISOString(),
       role: 'user',
+      author: entry.author,
       model: entry.model,
       content: entry.messages
         ? null
@@ -24,8 +25,9 @@ function createHTML (log) {
     entries.push({
       on: new Date(entry.date).toISOString(),
       role: 'model',
+      author: entry.model,
       model: entry.model,
-      content: entry.responses[0].content || JSON.stringify(entry.responses[0]),
+      text: entry.responses[0].content || JSON.stringify(entry.responses[0]),
       // Don't include unnecessary generation options
       generationOptions: { ...entry.generationOptions, maxTokens: undefined, stopSequences: undefined, enableCaching: undefined }
     })

--- a/src/tools/logging.js
+++ b/src/tools/logging.js
@@ -27,7 +27,7 @@ function createHTML (log) {
       role: 'model',
       author: entry.model,
       model: entry.model,
-      text: entry.responses[0].content || JSON.stringify(entry.responses[0]),
+      text: entry.responses[0].text || JSON.stringify(entry.responses[0]),
       // Don't include unnecessary generation options
       generationOptions: { ...entry.generationOptions, maxTokens: undefined, stopSequences: undefined, enableCaching: undefined }
     })

--- a/src/tools/loggingTemplate.html
+++ b/src/tools/loggingTemplate.html
@@ -38,12 +38,12 @@
 <script>
   document.getElementById('session-date').innerText = window.$DATE || new Date().toDateString()
   const messages = window.$ENTRIES || [
-    { role: 'user', model: 'gemini-1.5-pro-latest', on: new Date(), messages: [{ role: 'user', contents: [{ text: 'Image test' }, { imageURL: 'https://imgs.xkcd.com/comics/standards.png' }] }] },
-    { role: 'user', model: 'gemini-1.5-pro-latest', on: new Date(), messages: [{ role: 'user', contents: 'Hello!' }] },
+    { role: 'user', model: 'gemini-1.5-pro-latest', on: new Date(), messages: [{ role: 'user', parts: [{ text: 'Image test' }, { imageURL: 'https://imgs.xkcd.com/comics/standards.png' }] }] },
+    { role: 'user', model: 'gemini-1.5-pro-latest', on: new Date(), messages: [{ role: 'user', text: 'Hello!' }] },
     { role: 'model', content: 'This\nworks', model: 'gemini-1.5-pro-latest', on: new Date().toLocaleString() },
     { role: 'model', content: [{ text: 'ok' }, { text: '!' }], model: 'gemini-1.5-pro-latest', on: new Date().toLocaleString() }
   ]
-  function addMessage({ role, model, on, content, messages, generationOptions = {} }, i) {
+  function addMessage({ role, author, model, on, content, messages, generationOptions = {} }, i) {
     // const html = `
     //   <div class="message">
     //     <div class="role">
@@ -65,23 +65,23 @@
         html.appendChild(pre)
       } else if (Array.isArray(content)) {
         for (const part of content) {
-          if (part.imageURL || part.imageB64) {
-            if (part.imageB64) {
-              if (part.imageB64.startsWith('data:')) {
+          if (part.imageURL || part.imageB64Url) {
+            if (part.imageB64Url) {
+              if (part.imageB64Url.startsWith('data:')) {
                 const img = document.createElement('img')
-                img.src = part.imageB64
+                img.src = part.imageB64Url
                 html.appendChild(img)
                 continue
               } else {
                 const mimeType = part.mimeType
-                const dataUrl = `data:${mimeType};base64,${part.imageB64}`
+                const dataUrl = `data:${mimeType};base64,${part.imageB64Url}`
                 const img = document.createElement('img')
                 img.src = dataUrl
                 html.appendChild(img)
               }
             } else {
               const img = document.createElement('img')
-              img.src = part.imageURL || part.imageB64
+              img.src = part.imageURL || part.imageB64Url
               html.appendChild(img)
             }
           } else {
@@ -100,7 +100,7 @@
         const roleEl = document.createElement('pre')
         roleEl.innerText = `<|${message.role.toUpperCase()}|>`
         messageDiv.appendChild(roleEl)
-        const contentEl = contentToHTML(message.content)
+        const contentEl = contentToHTML(message.parts || message.content)
         messageDiv.appendChild(contentEl)
         contentHTML.appendChild(messageDiv)
       }
@@ -109,9 +109,9 @@
     }
     function onCopyContent() {
       if (messages) {
-        const textContent = messages.map(message => typeof message.content === 'string'
-          ? message.content
-          : message.content.map(part => part.text).join('\n')).join('\n')
+        const textContent = messages.map(message => typeof message.text
+          ? message.text
+          : message.parts.map(part => part.text).join('\n')).join('\n')
         navigator.clipboard.writeText(textContent)
       } else {
         const textContent = typeof content === 'string' ? content : content.map(part => part.text).join('\n')
@@ -127,7 +127,7 @@
 const { CompletionService } = require('langxlang')
 async function main () {
   const service = new CompletionService()
-  const [response] = await service.requestChatCompletion(${JSON.stringify(model)}, {
+  const [response] = await service.requestChatCompletion(${stringify(author, '    ')}, ${JSON.stringify(model)}, {
     messages: ${stringify(messages, '    ')},
     generationOptions: ${stringify(generationOptions || {}, '    ')}
   })
@@ -139,6 +139,7 @@ const { CompletionService } = require('langxlang')
 async function main () {
   const service = new CompletionService()
   const [response] = await service.requestCompletion(
+    ${stringify(author, '    ')},
     ${stringify(model, '    ')},
     '', /* system */
     ${stringify(content, '    ')}, /* user */

--- a/src/util.js
+++ b/src/util.js
@@ -126,4 +126,24 @@ function checkGuidance (messages, chunkCb) {
   return ''
 }
 
-module.exports = { sleep, cleanMessage, toTitleCase, getModelInfo, getRateLimit, checkDoesGoogleModelSupportInstructions, checkGuidance, knownModelInfo, knownModels }
+function Part (part) {
+  return Object.assign(part, {
+    get imageB64Url () {
+      if (part.imageB64Url) return part.imageB64Url
+      if (part.mimeType && part.data) {
+        const dataB64 = Buffer.from(part.data, 'base64')
+        return `data:${part.mimeType};base64,${dataB64}`
+      }
+    },
+    get mimeType () {
+      if (part.mimeType) return part.mimeType
+      if (part.imageB64Url) return part.imageB64Url.split(';')[0].slice(5)
+    },
+    get data () {
+      if (part.data) return part.data
+      if (part.imageB64Url) return Buffer.from(part.imageB64Url.split(',')[1], 'base64')
+    }
+  })
+}
+
+module.exports = { sleep, cleanMessage, toTitleCase, getModelInfo, getRateLimit, checkDoesGoogleModelSupportInstructions, checkGuidance, knownModelInfo, knownModels, Part }

--- a/src/util.js
+++ b/src/util.js
@@ -120,8 +120,8 @@ function checkGuidance (messages, chunkCb) {
     if (lastMsg !== guidance[0]) {
       throw new Error('Guidance message must be the last message')
     }
-    chunkCb?.({ done: false, content: guidance[0].content })
-    return guidance[0].content
+    chunkCb?.({ done: false, content: guidance[0].text })
+    return guidance[0].text
   }
   return ''
 }

--- a/test/api.js
+++ b/test/api.js
@@ -68,6 +68,7 @@ async function testGuidance () {
     console.log(result2)
     assert(result2.text.trim().startsWith('```json\n') && result2.text.trim().endsWith('```'), 'Guidance not followed by Gemini 1.0')
   }
+  console.log('Guidance test passed')
 }
 
 function toTerminal (chunk) {

--- a/test/api.js
+++ b/test/api.js
@@ -1,6 +1,7 @@
+process.env.DEBUG = '*'
 /* eslint-env mocha */
 // @ts-check
-const { CompletionService, ChatSession, Func: { Arg, Desc }, tools: { loadPrompt } } = require('langxlang')
+const { CompletionService, ChatSession, tools: { loadPrompt } } = require('langxlang')
 const fs = require('fs')
 const assert = require('assert')
 const openAIKey = fs.readFileSync('openai.key', 'utf8')
@@ -25,53 +26,58 @@ async function testListing () {
   console.dir(models, { depth: null })
 }
 
-async function testOpenAICompletion () {
-  const q = 'Hello! Why is the sky blue?'
-  const result = await completionService.requestCompletion('gpt-3.5-turbo', '', 'Hello! Why is the sky blue?')
-  console.log('Result for', q)
-  console.log(result)
-}
-
-async function testGeminiCompletion (model = 'gemini-1.0-pro') {
-  console.log('testGeminiCompletion with model', model)
-  const q = 'Hello! Why is the sky blue?'
-  const result = await completionService.requestCompletion(model, 'Speak like a pirate!', 'Hello! Why is the sky blue?', toTerminal)
-  console.log('Result for', q)
-  console.log(result)
-}
+// TODO: Fix. These are not real "completions" but "chat completions"
+// async function testOpenAICompletion () {
+//   const q = 'Hello! Why is the sky blue?'
+//   const result = await completionService.requestCompletion('openai', 'gpt-3.5-turbo', '', 'Hello! Why is the sky blue?')
+//   console.log('Result for', q)
+//   console.log(result)
+// }
+// async function testGeminiCompletion (model = 'gemini-1.0-pro') {
+//   console.log('testGeminiCompletion with model', model)
+//   const q = 'Hello! Why is the sky blue?'
+//   const result = await completionService.requestCompletion(model, 'Speak like a pirate!', 'Hello! Why is the sky blue?', toTerminal)
+//   console.log('Result for', q)
+//   console.log(result)
+// }
 
 async function testGuidance () {
   // EXPECTED = '```json\n{\n  "name": "AI",\n  "age": 30\n}\n```'
   const q = loadPrompt(guidanceStr, {})
-  const [result] = await completionService.requestChatCompletion('gpt-3.5-turbo', {
-    messages: [
-      { role: 'user', content: guidanceStr },
-      { role: 'guidance', content: '```json\n' }
-    ]
-  })
-  console.log('GPT-3.5 result for', q)
-  console.log(result)
-  assert(result.text.trim().startsWith('```json\n') && result.text.trim().endsWith('```'), 'Guidance not followed by GPT-3.5')
-  // Gemini API no longer supports guidance (last model message)
-  // const [result2] = await completionService.requestChatCompletion('gemini-1.0-pro', {
-  //   messages: [
-  //     { role: 'user', content: guidanceStr },
-  //     { role: 'guidance', content: '```json\n' }
-  //   ]
-  // })
-  // console.log('Gemini result for', q)
-  // console.log(result2)
-  // assert(result.text.trim().startsWith('```json\n') && result.text.trim().endsWith('```'), 'Guidance not followed by Gemini 1.0')
+  // OpenAI
+  {
+    const [result] = await completionService.requestChatCompletion('openai', 'gpt-3.5-turbo', {
+      messages: [
+        { role: 'user', text: guidanceStr },
+        { role: 'guidance', text: '```json\n' }
+      ]
+    })
+    console.log('GPT-3.5 result for', q)
+    console.log(result)
+    assert(result.text.trim().startsWith('```json\n') && result.text.trim().endsWith('```'), 'Guidance not followed by GPT-3.5')
+  }
+  // Gemini
+  {
+    const [result2] = await completionService.requestChatCompletion('google', 'gemini-1.5-flash', {
+      messages: [
+        { role: 'user', text: guidanceStr },
+        { role: 'guidance', text: '```json\n' }
+      ]
+    })
+    console.log('Gemini result for', q)
+    console.log(result2)
+    assert(result2.text.trim().startsWith('```json\n') && result2.text.trim().endsWith('```'), 'Guidance not followed by Gemini 1.0')
+  }
 }
 
 function toTerminal (chunk) {
   chunk.done
     ? process.stdout.write('\n')
-    : process.stdout.write(chunk.content)
+    : process.stdout.write(chunk.textDelta)
 }
 
 async function testSession () {
-  const session = new ChatSession(completionService, 'gpt-3.5-turbo', '', {
+  const session = new ChatSession(completionService, 'openai', 'gpt-3.5-turbo', '', {
     generationOptions: {
       temperature: 1
     }
@@ -89,34 +95,38 @@ async function testSession () {
   console.log('Done', followup, 'bytes')
 }
 
-async function testSessionWithGuidance () {
-  const session = new ChatSession(completionService, 'gpt-3.5-turbo', '')
-  const q = guidanceStr
-  console.log('> ', q)
-  const message = await session.sendMessage(loadPrompt(q, {}), toTerminal)
-  process.stdout.write('\n')
-  console.log('Done', message)
-}
+// async function testSessionWithGuidance () {
+//   const session = new ChatSession(completionService, 'openai', 'gpt-3.5-turbo', '')
+//   const q = guidanceStr
+//   console.log('> ', q)
+//   const message = await session.sendMessage(loadPrompt(q, {}), toTerminal)
+//   process.stdout.write('\n')
+//   console.log('Done', message)
+// }
 
-function getWeather (
-  location = Arg({ type: String, description: 'Specify the location' }),
-  unit = Arg({ type: ['C', 'F'], description: 'Specify the unit', default: 'C' })
-) {
-  Desc('This method returns the weather in the specified location')
+function getWeather ({ location, unit = 'C' }) {
   console.log('Getting weather with', arguments)
   if (unit === 'C') return { weather: 'sunny', temp: '25C' }
   else if (unit === 'F') return { weather: 'sunny', temp: '77F' }
   return '0'
 }
+getWeather.description = 'This method returns the weather in the specified location'
+getWeather.parameters = {
+  location: { type: 'string', description: 'Specify the location', required: true },
+  unit: { type: 'string', description: 'Specify the unit', required: false }
+}
 
 async function testOpenAISessionWithFuncs () {
-  async function getTime (timezone = Arg({ type: String, description: 'Specify the timezone' })) {
-    Desc('This method returns the current time in the specified timezone')
+  async function getTime ({ timezone }) {
     console.log('Getting time with', arguments)
     return new Date().toLocaleString()
   }
+  getTime.description = 'This method returns the current time in the specified timezone'
+  getTime.parameters = {
+    timezone: { type: 'string', description: 'Specify the timezone', required: false }
+  }
 
-  const session = new ChatSession(completionService, 'gpt-3.5-turbo', '', {
+  const session = new ChatSession(completionService, 'openai', 'gpt-3.5-turbo', '', {
     functions: { getTime, getWeather }
   })
   await session.sendMessage("Hey, what's the weather in Beijing?", toTerminal)
@@ -126,12 +136,13 @@ async function testOpenAISessionWithFuncs () {
 async function testGeminiSessionWithFuncs (model = 'gemini-1.0-pro') {
   console.log('testGeminiSessionWithFuncs with model', model)
   async function getTimeUTC () {
-    Desc('This method returns the current time in UTC')
+    // Desc('This method returns the current time in UTC')
     console.log('Getting time with', arguments.length, 'arguments')
     return new Date().toUTCString()
   }
+  getTimeUTC.description = 'This method returns the current time in UTC'
 
-  const session = new ChatSession(completionService, model, '', {
+  const session = new ChatSession(completionService, 'google', model, '', {
     functions: { getTimeUTC, getWeather }
   })
   const q = 'What time is it right now?'
@@ -145,7 +156,7 @@ async function testGeminiSessionWithFuncs (model = 'gemini-1.0-pro') {
 
 async function testOpenAICaching () {
   const q = 'Hello! Why is the sky blue?'
-  const result = await completionService.requestCompletion('gpt-3.5-turbo', '', 'Hello! Why is the sky blue?', null, {
+  const result = await completionService.requestCompletion('openai', 'gpt-3.5-turbo', 'Hello! Why is the sky blue?', null, {
     enableCaching: true
   })
   console.log('Cached result for', q)
@@ -155,14 +166,14 @@ async function testOpenAICaching () {
 async function testOptions () {
   const q = 'Hello! Why is the sky blue?'
   console.log('OptionsTest>', q)
-  const [resultGpt] = await completionService.requestCompletion('gpt-3.5-turbo', '', 'Hello! Why is the sky blue?', null, {
+  const [resultGpt] = await completionService.requestCompletion('openai', 'gpt-3.5-turbo', 'Hello! Why is the sky blue?', null, {
     maxTokens: 100,
     stopSequences: ['<SYSTEM>'],
     temperature: 2
   })
   console.log('GPT-3.5 with maxTokens=100, temp=2', resultGpt)
   console.log(resultGpt)
-  const [resultGemini] = await completionService.requestCompletion('gemini-1.0-pro', '', 'Hello! Why is the sky blue?', null, {
+  const [resultGemini] = await completionService.requestCompletion('google', 'gemini-1.5-flash', 'Hello! Why is the sky blue?', null, {
     maxTokens: 100,
     stopSequences: ['<SYSTEM>'],
     temperature: 2
@@ -173,31 +184,34 @@ async function testOptions () {
 const appleIcon64 = 'data:image/webp;base64,UklGRuwNAABXRUJQVlA4TOANAAAv/8A/EOJQ27aNJO0/9r3CdVdFxATwoNnrZrFiAwqOwbrz0t+r1WXb8v+btuU8Sq9/V+7S47tO9BZ5hFzmQXKXt+A1z3/3G+bsNfdaY4z/uOqqf9s2rnZsW2vHatvu2LYOYszYTk5cZYy2Vsdo27aZVZJi23ZtRSz1FrlH3fVTDxNZBR7QkN5YLyih2EiSI0lWpUPFESlOh78p6+f8xxcvAZIk07Zicfhs27Zt27Zt237v27Zt27Zt/2fcMwFwa9tWrbTy933jfvePQwSRu5O5u7unWoC7Q4//nftgnAKwyHp6NVAEbVADIbXcFHphkNGBA0mSTOu2875t27Zt27Zt3MVhAABGLGiHTtm2+TZzbCLJlqLiq7hU/PomLpCCF0wQkZNhBQFUT4AvAalkApJZSObUyVFf5DRUcM+RbJNkY5Jxw6FkLyUr7uQQpSaZDwB8dnzJTkomXGaSeZ9mm0t2oMgkx+G0IVWy0AKTHAPJfgx7luxweXUyWcleDXuX7KvkUKUlOYxkl4YNT5NMsLDkzQGSLR82leyLZFRhdbKMYWPJ9ntZdzIDyUabSeZfVp3TWMnuDBtLtsPLWrK+YWPJzkiOQFlJjq1k040kuyo5Ql7U8nqUZA+GTSV7LJmkl7VkNcOmkn2TTMvLupOpSPavyWclx80LW7LNw6aSVXphS461ZHNNHtQ5HVRYkgMlOzVsKNnnTo6UF7bkeAwbSsZb4IM5u0HtG2sjtVHaD/o9BxygDU80aL5FMiDZhSaSbfF+60NC2ky0xWpr1LZK2zFtd7S90/Zb26Q2njau1TarbVzbD21vtd3VdkrbRm092vK0eU80DX14k2aTHNePNpDsp+TI9WN2w9q0tWVoW67twaXtFGub0/ZH21VtS7SlaNPSI8Jikh0eNvylT7k2fm0h2lZre62N1/Zd23ttmy7RI2lrSY7BRxtI9mjRHGKKHqktQtueS9tB3VnbBW3F2hRNJdmyYUPJQn0qtYH3aVv0yXawX6ntiLZIPaLM1MnE/xQku9Q5DU3BxBGxhraLbYzaPmpr0iZtJMnybcWzvPHsxmjL1Pa8jVXbf23z3m4iyW4rSHZj0dNgE22EtrSr2pi1jWob0L5F7SM5xh9VkCzKe1/84QNoC9T2qI1d23dt2doI60jWN6RL9qaTQ/WmTVfbYW28NoG/02Zkm04OcXYDyanzXrXxaWt5ZZvGV2qr14c3toxkNsPeJZvoZPK9aLPV9rBNp7aT2uQMI1lPA8n2+uTaN6WtS9t0m9LztFmY5VbvDvhTA8nCJtOmqe16m1htt19kFcnRkGy2N8n+dDJmEm3Rh7ZpPVbben1IxK0qObnD3iVb73OcaOSrjm3Tqu3bP92ukrOzwYI5aBP/XpvWY7Xtmmhybld5ffBBvUn2XzKRB9Cmoe1Jm1ZtXw+Z/fAfcMNKjv6wd8mOu7trs92mTaq2OW1rtEm4aSUnq4HkVLi7Nh9t/9qkjrR5uHElW9Wgk5m5r/HKNqU3aqvTh2i3rmT3e5Pst2Skr/HKNqEbaNumTcXNK5mwZKO9SXbMtYVqm2oTqu2KNic3sGTmw94la3untok2ndpeaktY/OEDuoUlS2pwp4/fOm9sk6nti7Z87Zt1G0vW25sA4G6ffp9sU/kVbVV6xO+5BwJo4McVZITZI8YeURBiBBg2QALoj2S7e/MhxP365hJxnrbyiSbk+QaK0QI/KIIB2Abn4BF8hF8wATzgaq0wDf/gCzyDS7Ad+iATHEB0qg7vzQnoPVFbv7ZLP4vvc9/SfrCeaXYZMIIcWAE3YGxcpxpm4DGshDiQs0BefQWS/esNAE53n+ib1WatrUDbBm1PHxTPmdoOafPV4z/kWZ51fQBoQiHshe+1/zAFV6EOdJ7cAAACAPw0ADh8zvfv/2CiSWtz1Vahbbu2Z7Mf4kWg7YO2rl09y1weGDCD7nfUwYX70AQG3f0IegFQxaYDwD6Ju4MalMHlO/x5eHf8/TN351+/cRPh3pppsi9aXLE2N0fbD23r3nn/hj3LjAxUPRfm6mDPwJP1GVeGbxIAaAoAqs4JaLCGFrg5qnOOfG8yrg9F05fG6tdYpLdkHW3JFmfc1eM1LXOvz/9xd/n55+hdv/xVfO+XN5/nGexgM4zXKOEvnIEOCN48gP0WALqCA0D0xS4PxFUCH2iAQ9fXKUx83WXtn0rHb/W1r/7k34Jn8LOhmJ3wVlZcsjfritmcb/C5ZPeMA24EB3ed9e/C/IRBu8KFcY14BkbhUfB/u5w+51Hwnw433Jueqf0N/W9ekx93mYeH/PlLVf+trv7RWvrqyfwMx/8mQ71Zf2/eO1j0DL6mA7339sJPbecje/X09K9NPwIxDJkZcIKL4xq9K+KhAYsEXmc1ergPIcEFGQEN2F1T6PQ6aIJEBD4X8dX6G7DIRXBpqIPRmkSnw0QTNEbwd5WCCtMwElyhLIAx3KqJdFoMNMFiaSbhFa5b+rogKFmvplIaNTSDy+Giwiz0MlTiAoKwo6ZT6jU0g8djo1Y4z8gmbT48qAmVBg3NEAoYqfAhjHXCAjbwtabU6bLQpEbBSYX/EJwsxmu6JtXTyNHcyRArdSVISRT4rVfTGvhcCDqDAjwSuB7xUudCZpIYVxirqfV2S0BBZkAAdyGmuZ0LCQkC831rej3VzHc8oKEPzS9MgX9yAgr/qCn2b3ecVoMgYkABv8BjUq/xzVua433BJDG4LFytiQ58r/zHA//h4E0zvRtIpgWWVYNvES4XpwSigWexunVCAvLwq5p8U8Y0GWEv8OBqdLgJVCogcmy1ChWJAH54W80+fVkaoLEaHlYlAVca/lhuBIYp2KmaHrYnIIzEQtuNQC8+qK/G/2F0i+1F/sN6O4JEbBBezQ/lscFh+90SBsXFKMCk/cZgFRdTWAsQBuP6TQl8qXv5CcQURnJUAnWlmCCuFuGLY4K1ZQBnIwqDdyuD08MIxgMq4zKoN8fzplqIUB0P9JcC7IwHTpYCvIymu+/w/aXwOUYsFpCB6VKop8QCtrUYITYWiC+HZWJ5cTn8MBZYVA5fiAV2lwPcjgUulgO8C8A4nvyOcpgOLhEHLoL35QBzXNBxnPaYcqggFgcuuV5BgHwcP5hbEIx6HGGoWpCgFQfDlAToxgF0SRwQxw/GBTE/krkFAepxALlpQYByHGGI0wsijGwcuPgxBfHBOBh0cEF0hz+OMBBel8PovDgcHpbDdICIZJ1yODiAIoFT5fA99sBIfl4OL/dIYU05XBsLDJfDg2M5pBxgZSyQWw47xXJdOWwdCziXAyTHckA5gE8sILVpMfwolrBLTJfC6EGxOLwohW/i0tE8rRTgjUcLG0rhUfFAeynAxnggvRR+Gg+4lwJkxAOqpQCu8TB804UAivFw/g7gSRnAb2DjcdhfBnDfI4a+MnhbTExaGUBbTC8rg4tiYld4bhG8ISb/UglsGqCjggMlcItHfUkJfCqu95UAlMf113EBgFtc7JIH2+9zb43L4bj9XtO9PCAy6LQfbPLIIch+UBQbu1Jj84FlbADhufV2DHuY2BzWWe83Hv2K1tsvPkZvxni7xtcdBB9td3TYFY3PYYvtTvUEQrbtzkjB/LHpwCMFgM6x3DQjmAKHZZaDY55ECLPcJmkICG9qtzHopcGfZjd4c9vbDyARJ9rtKZ7IgO6M2cArFeyB8Nhqjwnwp8J3shps82T+x2oQnQ72oNVtdjQjnA6fZ7MHe0LB3mYQn5Lg4hMsBv9BJCW+vsX+6EkFU4sxoWn5/EfsdT3wpcW3thcs8cSGURiZC2xS41tY64ncH5AciLAWVHpyT4JPtoLxgFx6fH1bvc0TPH/GVL9Ikf/NUvBk1uVBSQoEWwqKPcnBQ5xjp4WHpslPtBMs9EQHV2yhlUagnSqHeVaCfZ7sMGorGYlxSpcfZqO9PeGMOcya6IUp810sBHcDOGnLW4iJ87QvsM8VYQ9OHDjOmCdMvCe+e34BOGodeBCGTJ2vPWOcp3v6Yadt4Hrw4AwwuitZZny25xCWWuZvnsXLFtplJTDLg7/YLj/0TAbY3ayykJHJhb9vbJRNPJu39iNY1Sa3dKHz4e852iIzl3tOodUisM6zyjBPtMf1Aam8+OVzzQHJnltYZI1dcGF2QGhjWywMo+T5ZdxGlhhDiucYhiwBu2adwSyd9HI7/CMg6XkG/W9aYcR4eK5XtMJ+nm12Aay1wYFdyHx52OWHuxb4OK6M5/z58CN/RwccPO+7rpS7MWR67s/N3VEHZc9hft4efJrn/+GX5WxvdgXcgmHY3+TrCpB0GwZXZJ1cbRxQdiv+4SN5+sfz3Y5hpOBOjuBdQMstyUjCtfycw2i6LT95YG5ueZBbExjYkJclP+j2DC76/Tgje+7hJn3fxbk4GgrdqmF0PjNYcy9+7pKXHXbY4/+2wu9Gg/W9l7ldg8usPxoYeHTUC0Gpe34hn3TWHhhGbtf9tp8ZlPG2y7ppX7bCQJyw33sY6I1xQRgVqHrHQMArCHTr7vEr+NWvuXDw7wHKp/jX4HLYpv1aD9o+6QZe9rG/6wc8/cDO3tcbH7bOTB++CQte6UZeFgo+MmPJ59Z5Sxhzzhd738Me8B6o+M2OUzL+3jIBGbd0wOQDvzm9lzF8+8xhUHs2iPvA4grcDOVrnQqf5/ZyNFyDruW7XtDNHYZmtMH7IkiFpEAchJ79H0YdVzAM4REymOFnVBiLV7/wIkj63z6MH2OAy+dLYAk='
 const bingImage = 'https://www.bing.com/th?id=OHR.CratersOfTheMoon_EN-US6516727783_1920x1080.jpg&w=1000'
 
-async function testRemoteImage (model = 'gpt-4-turbo') {
+async function testRemoteImage (author = 'openai', model = 'gpt-4-turbo') {
   console.log('Image complete with model', model)
-  const [result] = await completionService.requestCompletion(model, '', [
-    { text: "What's in this picture?" },
-    { imageURL: bingImage }
-  ], toTerminal)
+  const [result] = await completionService.requestChatCompletion(author, model, {
+    messages: [
+      { role: 'user', parts: [{ text: "What's in this image?" }, { imageURL: bingImage }] }
+    ]
+  }, toTerminal)
+
   console.log('Image result', result)
 }
 
-async function testImage (model = 'gemini-1.0-pro') {
+async function testImage (author = 'google', model = 'gemini-1.5-flash') {
   console.log('Image complete with model', model)
-  const [result] = await completionService.requestCompletion(model, '', [
-    { text: "What's in this image?" },
-    { imageB64: appleIcon64 }
-  ], toTerminal)
+  const [result] = await completionService.requestChatCompletion(author, model, {
+    messages: [
+      { role: 'user', parts: [{ text: "What's in this image?" }, { imageB64Url: appleIcon64 }] }
+    ]
+  }, toTerminal)
   console.log('Image result', result)
 }
 
-async function testSessionImage (model) {
-  const session = new ChatSession(completionService, model, '')
+async function testSessionImage (author, model) {
+  const session = new ChatSession(completionService, author, model, '')
   const q = "What's in this image?"
   console.log('> ', q)
   const message = await session.sendMessage([
     { text: "What's in this image?" },
-    { imageB64: appleIcon64 }
+    { imageB64Url: appleIcon64 }
   ], toTerminal)
   process.stdout.write('\n')
   console.log('Done', message)
@@ -207,18 +221,18 @@ async function testTokenCounting () {
   const text = 'Hello, World!'
   const content = [{ text }]
   {
-    const tokens = await completionService.countTokens('gpt-3.5-turbo', text)
+    const tokens = await completionService.countTokens('openai', 'gpt-3.5-turbo', text)
     console.log('GPT-3.5/4 Tokens in', text, 'is', tokens)
     assert.strictEqual(tokens, 4)
-    const tokensGemini = await completionService.countTokens('gemini-1.0-pro', text)
+    const tokensGemini = await completionService.countTokens('google', 'gemini-1.0-pro', text)
     console.log('Gemini 1.0 Tokens in', text, 'is', tokensGemini)
     assert.strictEqual(tokensGemini, 5)
   }
   {
-    const tokens = await completionService.countTokens('gpt-3.5-turbo', content)
+    const tokens = await completionService.countTokens('openai', 'gpt-3.5-turbo', content)
     console.log('GPT-3.5/4 Tokens in', text, 'is', tokens)
     assert.strictEqual(tokens, 4)
-    const tokensGemini = await completionService.countTokens('gemini-1.0-pro', content)
+    const tokensGemini = await completionService.countTokens('google', 'gemini-1.0-pro', content)
     console.log('Gemini 1.0 Tokens in', text, 'is', tokensGemini)
     assert.strictEqual(tokensGemini, 5)
   }
@@ -227,22 +241,22 @@ async function testTokenCounting () {
 async function testBasic () {
   completionService.startLogging()
   await testListing()
-  await testOpenAICompletion()
-  await testGeminiCompletion('gemini-1.0-pro')
-  await testGeminiCompletion('gemini-1.5-pro-latest')
+  // await testOpenAICompletion()
+  /* await testGeminiCompletion('gemini-1.0-pro') */
+  /* await testGeminiCompletion('gemini-1.5-pro-latest') */
   await testGuidance()
-  await testSessionWithGuidance()
+  /* await testSessionWithGuidance() */
   await testSession()
   await testOpenAISessionWithFuncs()
-  await testGeminiSessionWithFuncs('gemini-1.0-pro')
-  await testGeminiSessionWithFuncs('gemini-1.5-pro-latest')
+  /* await testGeminiSessionWithFuncs('gemini-1.0-pro') */
+  await testGeminiSessionWithFuncs('gemini-1.5-flash')
   await testOpenAICaching()
   await testOptions()
-  await testImage('gemini-pro-vision')
-  await testImage('gpt-4-turbo')
-  await testRemoteImage('gemini-pro-vision')
-  await testRemoteImage('gpt-4-turbo')
-  await testSessionImage('gemini-pro-vision')
+  await testImage('google', 'gemini-1.5-flash')
+  await testImage('openai', 'gpt-4-turbo')
+  await testRemoteImage('google', 'gemini-1.5-flash')
+  await testRemoteImage('openai', 'gpt-4-turbo')
+  await testSessionImage('google', 'gemini-pro-vision')
   await testTokenCounting()
   const log = completionService.stopLogging()
   const html = log.exportHTML()
@@ -254,14 +268,14 @@ if (typeof describe === 'function') {
   describe('API tests', function () {
     this.timeout(1000 * 60 * 5) // 5 minutes
     it('should list models', testListing)
-    it('should complete with OpenAI', testOpenAICompletion)
-    it('should complete with Gemini 1.0', () => testGeminiCompletion('gemini-1.0-pro'))
-    it('should complete with Gemini 1.5', () => testGeminiCompletion('gemini-1.5-pro-latest'))
+    // it('should complete with OpenAI', testOpenAICompletion)
+    // it('should complete with Gemini 1.0', () => testGeminiCompletion('gemini-1.0-pro'))
+    // it('should complete with Gemini 1.5', () => testGeminiCompletion('gemini-1.5-pro-latest'))
     it('should provide guidance', testGuidance)
-    it('should provide guidance in a session', testSessionWithGuidance)
+    // it('should provide guidance in a session', testSessionWithGuidance)
     it('should complete in a session', testSession)
     it('should complete in a session with functions', testOpenAISessionWithFuncs)
-    it('should complete in a session with functions for Gemini 1.0', () => testGeminiSessionWithFuncs('gemini-1.0-pro'))
+    // it('should complete in a session with functions for Gemini 1.0', () => testGeminiSessionWithFuncs('gemini-1.0-pro'))
     it('should complete in a session with functions for Gemini 1.5', () => testGeminiSessionWithFuncs('gemini-1.5-pro-latest'))
     it('should cache results', testOpenAICaching)
   })

--- a/test/flow.test.js
+++ b/test/flow.test.js
@@ -52,7 +52,7 @@ const chain = (params) => ({
 })
 
 const dummyCompletionService = {
-  requestChatCompletion: async (model, { messages, generationOpts }, chunkCb) => {
+  requestChatCompletion: async (author, model, { messages, generationOpts }, chunkCb) => {
     assert(messages.every(msg => ['user', 'assistant'].includes(msg.role)))
     const mergedPrompt = messages.map(m => m.content).join('\n')
     // console.log('mergedPrompt', [mergedPrompt], messages)


### PR DESCRIPTION
Breaking changes

* CompletionService now takes `author` parameter before `requestCompletion`, `requestChatCompletion`, `countTokensInMessages` and `countTokens`
* ChatSession now takes in author before `model`
* Functions are now handled more naturally with properties on the function object itself
* `parts` is now used over `content` in all messages. `parts` is always an array of MessageParts.
  * `text` is now accepted for messages that are just text / would just be one MessagePart
* Various fixes to function calling