### PR TITLE
Add audio APIs, new ChatSession methods, token usage information

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ Note: as an alternative to explicitly passing the API keys in the constructor yo
 * or, define the keys inside `/.local/share/lxl-cache.json` (linux), `~/Library/Application Support/lxl-cache.json` (mac), or `%appdata%\lxl-cache.json` (windows) with the structure
 `{"keys": {"openai": "your-openai-key", "gemini": "your-gemini-key"}}`
 
-#### `async requestCompletion(author: string, model: string, systemPrompt: string, userPrompt: string)`
+#### `async requestCompletion(author: string, model: string, systemPrompt: string, userPrompt: string): Promise<CompletionResponse[]>`
 
 Request a non-streaming completion from the model.
 
@@ -106,6 +106,17 @@ Request a non-streaming completion from the model.
 Request a completion from the model with a sequence of chat messages which have roles. A message should look like
 `{ role: 'user', content: 'Hello!' }` or `{ role: 'system', content: 'Hi!' }`. The `role` can be either `user`, `system` or `assistant`, no
 matter the model in use.
+
+#### Request usage
+
+Both .requestCompletion and .requestChatCompletion return an array of `CompletionResponse` objects. Each object has the following properties:
+```ts
+type: 'text' | 'function', parts: MessagePart[], text?: string, fnCalls?: FnCalls, requestUsage?: Usage
+```
+
+Inside .requestUsage is an object that contains token usage for the request in the format of `{ inputTokens: number, outputTokens: number, totalTokens: number, cachedInputTokens?: number }`.
+
+Note that the `.requestUsage` is global to the request, so it's the sum of all the tokens in all the choices processed as input and output'ed in the request.
 
 ### ChatSession
 

--- a/src/ChatSession.js
+++ b/src/ChatSession.js
@@ -25,13 +25,17 @@ class ChatSession {
     this.messages = []
     if (systemMessage) this.messages.push({ role: 'system', parts: typeof systemMessage === 'string' ? [{ text: systemMessage }] : systemMessage })
     if (options.functions) {
-      this.functions = options.functions
-      this.loading = this._loadFunctions(options.functions)
+      this.setFunctions(options.functions)
     } else {
       this.loading = Promise.resolve()
     }
 
     this._calledFunctionsForRound = []
+  }
+
+  setFunctions (functions) {
+    this.functions = functions
+    this.loading = this._loadFunctions(functions)
   }
 
   async _loadFunctions (functions) {
@@ -164,6 +168,12 @@ class ChatSession {
     } else {
       this.messages.push({ role: 'user', text: message })
     }
+    return this._sendMessages(chunkCb, options)
+  }
+
+  async setAndSendMessages (messages, chunkCb, options) {
+    await this.loading
+    this.messages = messages
     return this._sendMessages(chunkCb, options)
   }
 }

--- a/src/ChatSession.js
+++ b/src/ChatSession.js
@@ -158,6 +158,10 @@ class ChatSession {
     if (guidanceIx !== -1) {
       this.messages.splice(guidanceIx, 1)
     }
+    const calledFunctions = []
+    for (const round of this._calledFunctionsForRound) {
+      calledFunctions.push(...Object.values(round))
+    }
     return { parts: response.parts, text: response.text, calledFunctions: this._calledFunctionsForRound }
   }
 

--- a/src/ChatSession.js
+++ b/src/ChatSession.js
@@ -159,7 +159,7 @@ class ChatSession {
     for (const round of this._calledFunctionsForRound) {
       calledFunctions.push(...Object.values(round))
     }
-    return { parts: response.parts, text: response.text, calledFunctions: this._calledFunctionsForRound, endReason: response.type }
+    return { parts: response.parts, text: response.text, calledFunctions: this._calledFunctionsForRound, endReason: response.type, usage: response.requestUsage }
   }
 
   async sendMessage (message, chunkCb, options) {

--- a/src/ChatSession.js
+++ b/src/ChatSession.js
@@ -135,9 +135,6 @@ class ChatSession {
       this._calledFunctionsForRound.push(response.fnCalls)
     } else if (response.type === 'function') {
       this._calledFunctionsForRound.push(response.fnCalls)
-      if (Array.isArray(response.fnCalls) && !response.fnCalls.length) {
-        throw new Error('No function calls returned, but type is function')
-      }
       // we need to call the function with the payload and then send the result back to the model
       for (const index in response.fnCalls) {
         const call = response.fnCalls[index]
@@ -162,7 +159,7 @@ class ChatSession {
     for (const round of this._calledFunctionsForRound) {
       calledFunctions.push(...Object.values(round))
     }
-    return { parts: response.parts, text: response.text, calledFunctions: this._calledFunctionsForRound }
+    return { parts: response.parts, text: response.text, calledFunctions: this._calledFunctionsForRound, endReason: response.type }
   }
 
   async sendMessage (message, chunkCb, options) {

--- a/src/CompleteImpls.js
+++ b/src/CompleteImpls.js
@@ -268,7 +268,8 @@ class OpenAICompleteService extends BaseCompleteService {
         // fnCalls: choice.fnCalls && Object.fromEntries(Object.entries(choice.fnCalls).map(([key, value]) => [key, { id: value.id, name: value.name, args: JSON.parse(value.args) }])),
         fnCalls: choice.fnCalls && Object.values(choice.fnCalls).map((value) => ({ id: value.id, name: value.name, args: JSON.parse(value.args) })),
         parts,
-        text: content
+        text: content,
+        requestUsage: response.usage
       }
     })
   }

--- a/src/CompleteImpls.js
+++ b/src/CompleteImpls.js
@@ -221,6 +221,7 @@ class OpenAICompleteService extends BaseCompleteService {
           for (const key in msg.parts) {
             const value = msg.parts[key]
             if (value.text) {
+              if (typeof value.text !== 'string') throw new Error('Expected part.text to be a string: ' + JSON.stringify(value))
               updated.push({ type: 'text', text: value.text })
             } else if (value.imageURL) {
               updated.push({ type: 'image_url', image_url: { url: value.imageURL, detail: value.imageDetail } })
@@ -236,6 +237,9 @@ class OpenAICompleteService extends BaseCompleteService {
             }
           }
           msg.content = updated
+          if (msg.content.every((e) => e.type === 'text')) {
+            msg.content = msg.content.map((e) => e.text).join('')
+          }
           delete msg.parts
         }
         return msg

--- a/src/CompleteImpls.js
+++ b/src/CompleteImpls.js
@@ -243,7 +243,7 @@ class OpenAICompleteService extends BaseCompleteService {
           delete msg.parts
         }
         return msg
-      }).filter((msg) => msg.content),
+      }).filter((msg) => msg.content || msg.tool_calls),
       {
         baseURL: this.apiBase,
         apiKey: this.apiKey,

--- a/src/CompleteImpls.js
+++ b/src/CompleteImpls.js
@@ -139,18 +139,9 @@ class GeminiCompleteService extends BaseCompleteService {
       return [result]
     } else if (response.functionCalls()) {
       const calls = response.functionCalls()
-      const fnCalls = {}
-      for (let i = 0; i < calls.length; i++) {
-        const call = calls[i]
-        fnCalls[i] = {
-          id: i,
-          name: call.name,
-          args: call.args
-        }
-      }
       const result = {
         type: 'function',
-        fnCalls,
+        fnCalls: calls,
         // TODO: map the content parts here to LXL's format
         parts: response.parts,
         safetyRatings: response.safetyRatings
@@ -273,7 +264,9 @@ class OpenAICompleteService extends BaseCompleteService {
       return {
         type: choiceType,
         isTruncated: choice.finishReason === 'length',
-        fnCalls: choice.fnCalls,
+        // { 0: { id: 'call_n', name: 'Classify', args: '{"choice":"Angry"}' } } => [ { id: 'call_n', name: 'Classify', args: { choice: 'Angry' } } ]
+        // fnCalls: choice.fnCalls && Object.fromEntries(Object.entries(choice.fnCalls).map(([key, value]) => [key, { id: value.id, name: value.name, args: JSON.parse(value.args) }])),
+        fnCalls: choice.fnCalls && Object.values(choice.fnCalls).map((value) => ({ id: value.id, name: value.name, args: JSON.parse(value.args) })),
         parts,
         text: content
       }

--- a/src/CompleteImpls.js
+++ b/src/CompleteImpls.js
@@ -161,8 +161,12 @@ class GeminiCompleteService extends BaseCompleteService {
     }
   }
 
-  async requestTranscription(model, audioStream, options) {
+  async requestTranscription (model, audioStream, options) {
     throw new Error('Transcription is not supported for Gemini yet - use OpenAI instead')
+  }
+
+  requestSpeechSynthesis (model, text, options) {
+    throw new Error('Speech synthesis is not supported for Gemini yet - use OpenAI instead')
   }
 
   async countTokens (model, content) {
@@ -272,8 +276,13 @@ class OpenAICompleteService extends BaseCompleteService {
     })
   }
 
-  async requestTranscription(model, audioStream, options) {
+  async requestTranscription (model, audioStream, options) {
     const res = await openai.transcribeAudioEx(this.apiBase, this.apiKey, model, audioStream, options)
+    return res
+  }
+
+  async requestSpeechSynthesis (model, text, options) {
+    const res = await openai.synthesizeSpeechEx(this.apiBase, this.apiKey, model, text, options)
     return res
   }
 

--- a/src/CompleteServices.js
+++ b/src/CompleteServices.js
@@ -161,6 +161,10 @@ class GeminiCompleteService extends BaseCompleteService {
     }
   }
 
+  async requestTranscription(model, audioStream, options) {
+    throw new Error('Transcription is not supported for Gemini yet - use OpenAI instead')
+  }
+
   async countTokens (model, content) {
     let parts = content
     if (!Array.isArray(content)) {
@@ -266,6 +270,11 @@ class OpenAICompleteService extends BaseCompleteService {
         text: content
       }
     })
+  }
+
+  async requestTranscription(model, audioStream, options) {
+    const res = await openai.transcribeAudioEx(this.apiBase, this.apiKey, model, audioStream, options)
+    return res
   }
 
   async listModels () {

--- a/src/CompletionService.js
+++ b/src/CompletionService.js
@@ -66,8 +66,8 @@ class CompletionService {
     if (options.enableCaching) {
       const cachedResponse = await caching.getCachedResponse(model, ['', text])
       if (cachedResponse) {
-        chunkCb?.({ done: false, content: cachedResponse.text })
-        chunkCb?.({ done: true, delta: '' })
+        chunkCb?.({ done: false, textDelta: cachedResponse.text, parts: cachedResponse.parts })
+        chunkCb?.({ done: true, textDelta: '' })
         return [cachedResponse]
       }
     }
@@ -79,7 +79,7 @@ class CompletionService {
     const saveIfCaching = (responses) => {
       this.log?.push(structuredClone({ author, model, system: '', user: text, responses, generationOptions: genOpts, date: new Date() }))
       const [response] = responses
-      if (response && response.content && options.enableCaching) {
+      if (response && response.parts && options.enableCaching) {
         caching.addResponseToCache(model, ['', text], response)
       }
       return responses
@@ -105,15 +105,15 @@ class CompletionService {
     if (enableCaching) {
       const cachedResponse = await caching.getCachedResponse(model, messages)
       if (cachedResponse) {
-        chunkCb?.({ done: false, content: cachedResponse.text })
-        chunkCb?.({ done: true, delta: '' })
+        chunkCb?.({ done: false, textDelta: cachedResponse.text, parts: cachedResponse.parts })
+        chunkCb?.({ done: true, textDelta: '' })
         return [cachedResponse]
       }
     }
     const saveIfCaching = (responses) => {
       this.log?.push(structuredClone({ author, model, messages, responses, generationOptions, date: new Date() }))
       const [response] = responses
-      if (response && response.content && enableCaching) {
+      if (response && response.parts && enableCaching) {
         caching.addResponseToCache(model, messages, response)
       }
       return responses

--- a/src/CompletionService.js
+++ b/src/CompletionService.js
@@ -54,7 +54,7 @@ class CompletionService {
   _getService (author) {
     const service = this.servicesByAuthor[author]
     if (!service) throw new Error(`No such model family: ${author}`)
-    if (!service.ok()) throw new Error(`No API key for ${author}`)
+    if (!service.ok()) throw new Error(`No API key for model provider '${author}' was provided`)
     return service
   }
 

--- a/src/CompletionService.js
+++ b/src/CompletionService.js
@@ -2,7 +2,7 @@ const { cleanMessage } = require('./util')
 const caching = require('./caching')
 const logging = require('./tools/logging')
 
-const { OpenAICompleteService, GeminiCompleteService } = require('./CompleteServices')
+const { OpenAICompleteService, GeminiCompleteService } = require('./CompleteImpls')
 
 function assert (condition, message = 'Assertion failed') {
   if (!condition) throw new Error(message)
@@ -123,9 +123,15 @@ class CompletionService {
     return saveIfCaching(ret)
   }
 
-  async requestTranscription (author, model, audioStream, options = {}) {
+  async requestTranscription (author, model, audioStream, format, options = {}) {
     const service = this._getService(author)
+    options.responseFormat = format
     return service.requestTranscription(model, audioStream, options)
+  }
+
+  async requestSpeechSynthesis (author, model, text, options = {}) {
+    const service = this._getService(author)
+    return service.requestSpeechSynthesis(model, text, options)
   }
 
   async countTokens (author, model, content) {

--- a/src/CompletionService.js
+++ b/src/CompletionService.js
@@ -123,6 +123,11 @@ class CompletionService {
     return saveIfCaching(ret)
   }
 
+  async requestTranscription (author, model, audioStream, options = {}) {
+    const service = this._getService(author)
+    return service.requestTranscription(model, audioStream, options)
+  }
+
   async countTokens (author, model, content) {
     const service = this._getService(author)
     return service.countTokens(model, content)

--- a/src/backends/openai.js
+++ b/src/backends/openai.js
@@ -172,13 +172,33 @@ async function generateCompletion (model, system, user, options = {}) {
   return completion
 }
 
+async function transcribeAudioEx (apiBase, apiKey, model, stream, options) {
+  const openai = new OpenAI({ apiKey, baseURL: apiBase })
+  const payload = {
+    model,
+    file: stream instanceof Buffer ? new Blob([stream], { type: 'audio/wav' }) : stream,
+    temperature: options.temperature,
+    response_format: options.responseFormat,
+    timestamp_granularities: options.granularity
+  }
+
+  if (payload.timestamp_granularities === 'word' || payload.timestamp_granularities === 'sentence') {
+    if (!payload.response_format) {
+      payload.response_format = 'verbose_json'
+    }
+  }
+
+  const transcription = await openai.speech.transcription.create(payload)
+  return transcription
+}
+
 async function listModels (baseURL, apiKey) {
   const openai = new OpenAI({ baseURL, apiKey })
   const list = await openai.models.list()
   return list.body.data
 }
 
-module.exports = { generateCompletion, generateChatCompletionEx, generateChatCompletionIn, listModels }
+module.exports = { generateCompletion, generateChatCompletionEx, generateChatCompletionIn, transcribeAudioEx, listModels }
 
 /*
 via https://platform.openai.com/docs/guides/text-generation/chat-completions-api

--- a/src/backends/openai.js
+++ b/src/backends/openai.js
@@ -192,13 +192,27 @@ async function transcribeAudioEx (apiBase, apiKey, model, stream, options) {
   return transcription
 }
 
+async function synthesizeSpeechEx (apiBase, apiKey, model, text, options) {
+  const openai = new OpenAI({ apiKey, baseURL: apiBase })
+  const payload = {
+    model,
+    text,
+    voice: options.voice,
+    speed: options.speed,
+    pitch: options.pitch,
+    volume: options.volume
+  }
+  const speech = await openai.speech.synthesis.create(payload)
+  return speech
+}
+
 async function listModels (baseURL, apiKey) {
   const openai = new OpenAI({ baseURL, apiKey })
   const list = await openai.models.list()
   return list.body.data
 }
 
-module.exports = { generateCompletion, generateChatCompletionEx, generateChatCompletionIn, transcribeAudioEx, listModels }
+module.exports = { generateCompletion, generateChatCompletionEx, generateChatCompletionIn, transcribeAudioEx, synthesizeSpeechEx, listModels }
 
 /*
 via https://platform.openai.com/docs/guides/text-generation/chat-completions-api

--- a/src/backends/openai.js
+++ b/src/backends/openai.js
@@ -1,5 +1,4 @@
 const OpenAI = require('openai')
-const https = require('https')
 const debug = require('debug')('lxl')
 const SafetyError = require('../SafetyError')
 
@@ -12,16 +11,14 @@ function safetyCheck (choices) {
     } else {
       throw new SafetyError('Completions were blocked by OpenAI safety filter')
     }
-  } else {
-    return choices
   }
+  return choices
 }
 
 function createChunkProcessor (chunkCb, resultChoices) {
   return function (chunk) {
-    // debug('[OpenAI] Chunk', JSON.stringify(chunk))
     if (!chunk) {
-      chunkCb?.({ done: true, delta: '' })
+      chunkCb?.({ done: true, textDelta: '', parts: [] })
       return
     }
     for (const choiceId in chunk.choices) {
@@ -56,16 +53,15 @@ function createChunkProcessor (chunkCb, resultChoices) {
           }
         } else if (delta.content) {
           resultChoice.content += delta.content
-          chunkCb?.({ n: choiceId, textDelta: delta.content, done: false })
+          chunkCb?.({ n: Number(choiceId), textDelta: delta.content, parts: [{ text: delta.content }], done: false })
         }
       } else throw new Error('Unknown chunk type')
     }
   }
 }
 
-// With OpenAI's Node.js SDK
 async function generateChatCompletionEx (model, messages, options, chunkCb) {
-  const openai = new OpenAI(options) // .baseURL to change API endpoint
+  const openai = new OpenAI(options)
   const completion = await openai.chat.completions.create({
     model,
     messages,
@@ -82,71 +78,58 @@ async function generateChatCompletionEx (model, messages, options, chunkCb) {
   return { choices: safetyCheck(resultChoices) }
 }
 
-// Directly use the OpenAI REST API
-function _sendApiChatComplete (apiBase, apiKey, payload, chunkCb) {
-  const url = new URL(apiBase + '/chat/completions')
-  const chunkPrefixLen = 'data: '.length
-  const options = {
-    hostname: url.hostname,
-    port: 443,
-    path: url.pathname,
+// Updated to use Fetch API
+async function _sendApiChatComplete (apiBase, apiKey, payload, chunkCb) {
+  const url = new URL(`${apiBase}/chat/completions`)
+  const headers = {
+    Accept: 'text/event-stream',
+    'Content-Type': 'application/json',
+    'Cache-Control': 'no-cache',
+    Connection: 'keep-alive',
+    Authorization: `Bearer ${apiKey}`
+  }
+
+  debug('[OpenAI] /completions Payload', url.toString(), headers, JSON.stringify(payload))
+
+  const response = await fetch(url, {
     method: 'POST',
-    headers: {
-      Accept: 'text/event-stream',
-      'Content-Type': 'application/json',
-      'Cache-Control': 'no-cache',
-      Connection: 'keep-alive',
-      Authorization: 'Bearer ' + apiKey
+    headers,
+    body: JSON.stringify(payload)
+  })
+
+  if (!response.ok) {
+    const errorText = await response.text()
+    debug(`[OpenAI] Server returned status code ${response.status}`, errorText)
+    throw new Error(`Server returned status code ${response.status}: ${errorText}`)
+  }
+
+  if (!payload.stream) {
+    const data = await response.json()
+    chunkCb(data)
+    return
+  }
+
+  const reader = response.body.getReader()
+  const decoder = new TextDecoder('utf-8')
+  let buffer = ''
+
+  while (true) {
+    const { done, value } = await reader.read()
+    if (done) break
+
+    buffer += decoder.decode(value)
+    const lines = buffer.split('\n')
+    buffer = lines.pop() // Keep incomplete line in buffer
+
+    for (const line of lines) {
+      if (line === 'data: [DONE]') {
+        chunkCb(null)
+      } else if (line.startsWith('data: ')) {
+        const jsonData = line.slice('data: '.length)
+        chunkCb(JSON.parse(jsonData))
+      }
     }
   }
-  if (url.protocol === 'https:') {
-    options.port = 443
-  } else if (url.protocol === 'http:') {
-    options.port = 80
-  }
-  debug('[OpenAI] /completions Payload', JSON.stringify(payload))
-  return new Promise((resolve, reject) => {
-    const req = https.request(options, (res) => {
-      if (res.statusCode !== 200) {
-        debug(`[OpenAI] Server returned status code ${res.statusCode}`, res.statusMessage, res.headers)
-        reject(new Error(`Server returned status code ${res.statusCode} ${res.statusMessage}`))
-        return
-      }
-      res.setEncoding('utf-8')
-
-      let buffer = ''
-      if (payload.stream) {
-        res.on('data', (chunk) => {
-          buffer += chunk
-          const lines = buffer.split('\n')
-          buffer = lines.pop() // ''
-
-          for (const line of lines) {
-            if (line === 'data: [DONE]') {
-              chunkCb(null)
-              resolve()
-            } else if (line.startsWith('data: ')) {
-              chunkCb(JSON.parse(line.slice(chunkPrefixLen)))
-            }
-          }
-        })
-      } else {
-        res.on('data', (chunk) => {
-          buffer += chunk
-        })
-        res.on('end', () => {
-          chunkCb(JSON.parse(buffer))
-          resolve()
-        })
-      }
-    })
-
-    req.on('error', (error) => {
-      reject(error)
-    })
-    req.write(JSON.stringify(payload))
-    req.end()
-  })
 }
 
 async function generateChatCompletionIn (model, messages, options, chunkCb) {
@@ -212,7 +195,14 @@ async function listModels (baseURL, apiKey) {
   return list.body.data
 }
 
-module.exports = { generateCompletion, generateChatCompletionEx, generateChatCompletionIn, transcribeAudioEx, synthesizeSpeechEx, listModels }
+module.exports = {
+  generateCompletion,
+  generateChatCompletionEx,
+  generateChatCompletionIn,
+  transcribeAudioEx,
+  synthesizeSpeechEx,
+  listModels
+}
 
 /*
 via https://platform.openai.com/docs/guides/text-generation/chat-completions-api

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -14,7 +14,8 @@ export type ChunkCb = ({ n: number, textDelta: string, parts: MessagePart, done:
 export type FnCall = { id?: number, name: string, args: Record<string, any> }
 // TODO: Turn FnCalls from Record<number, FnCall> to FnCall[] (breaking)
 export type FnCalls = FnCall[]
-export type CompletionResponse = { type: 'text' | 'function', parts: MessagePart[], text?: string, fnCalls?: FnCalls }
+export type Usage = { inputTokens: number, outputTokens: number, totalTokens: number, cachedInputTokens?: number }
+export type CompletionResponse = { type: 'text' | 'function', parts: MessagePart[], text?: string, fnCalls?: FnCalls, requestUsage?: Usage }
 
 declare module 'langxlang' {
   type CompletionOptions = {
@@ -146,7 +147,8 @@ declare module 'langxlang' {
     sendMessage(userMessage: string | MessagePart[], chunkCallback?: ChunkCb, generationOptions?: CompletionOptions & { endOnFnCall?: boolean }): Promise<{
       parts: MessagePart[],
       text?: string,
-      calledFunctions: FnCalls[]
+      calledFunctions: FnCalls[],
+      usage?: Usage
     }>
 
     setFunctions(functions: Functions): void
@@ -155,7 +157,7 @@ declare module 'langxlang' {
       messages: Message[],
       chunkCallback?: ChunkCb,
       generationOptions?: CompletionOptions & { endOnFnCall?: boolean }
-    ): Promise<{ parts: MessagePart[], text?: string, calledFunctions: FnCall[][], endReason: 'text' | 'function' }>
+    ): Promise<{ parts: MessagePart[], text?: string, calledFunctions: FnCall[][], endReason: 'text' | 'function', usage?: Usage }>
   }
 
   // ============ TOOLS ============

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -39,7 +39,7 @@ declare module 'langxlang' {
     // `{"keys": {"openai": "your-openai-key", "gemini": "your-gemini-key"}}`
     // In this options object, you can specify generation options that will be applied by default to
     // all requestCompletion calls. You can override these options by passing them in the requestCompletion call.
-    constructor(apiKeys: Record<ModelAuthor, string>, options?: { apiBase?: string, generationOptions: CompletionOptions })
+    constructor(apiKeys: { [k in ModelAuthor]?: string }, options?: { apiBase?: string, generationOptions?: CompletionOptions })
 
     cachePath: string
 

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,3 +1,5 @@
+import { FsReadStream } from "openai/_shims/node-types.mjs"
+
 type ModelAuthor = 'google' | 'openai'
 type Model = 'gpt-3.5-turbo-16k' | 'gpt-3.5-turbo' | 'gpt-4' | 'gpt-4-turbo-preview' | 'gemini-1.0-pro' | 'gemini-1.5-pro-latest'
 type Role = 'system' | 'user' | 'assistant' | 'guidance'
@@ -24,6 +26,12 @@ declare module 'langxlang' {
     temperature?: number
     topP?: number
     topK?: number
+  }
+
+  type TranscriptionOptions = {
+    temperature?: number,
+    // responseFormat?:  | 'text' | 'srt' | 'verbose_json' | 'vtt',
+    granularity?: 'word' | 'sentence',
   }
 
   class CompletionService {
@@ -55,6 +63,22 @@ declare module 'langxlang' {
     }): Promise<CompletionResponse[]>
     // Request a completion from the model with a sequence of chat messages which have roles.
     requestChatCompletion(author: ModelAuthor | string, model: Model | string, options: { messages: Message[], generationOptions?: CompletionOptions }, chunkCb?: ChunkCb): Promise<CompletionResponse[]>
+
+    requestTranscription(author: ModelAuthor | string, model: Model | string, audioStream: FsReadStream | Blob | Buffer, format: 'json', options?: TranscriptionOptions): Promise<{ text: string }>
+    requestTranscription(author: ModelAuthor | string, model: Model | string, audioStream: FsReadStream | Blob | Buffer, format: 'verbose_json', options?: TranscriptionOptions): Promise<{
+      language: string,
+      text: string,
+      segments?: {
+        start: number,
+        end: number,
+        word: string
+      }[],
+      words?: {
+        start: number,
+        end: number,
+        word: string
+      }[]
+    }>
   }
 
   // Note: GoogleAIStudioCompletionService does NOT use the official AI Studio API, but instead uses a relay server to forward requests to an AIStudio client.

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,23 +1,20 @@
-import { FsReadStream } from "openai/_shims/node-types.mjs"
-
-type ModelAuthor = 'google' | 'openai'
-type Model = 'gpt-3.5-turbo-16k' | 'gpt-3.5-turbo' | 'gpt-4' | 'gpt-4-turbo-preview' | 'gemini-1.0-pro' | 'gemini-1.5-pro-latest'
-type Role = 'system' | 'user' | 'assistant' | 'guidance'
-type MessagePart =
+export type ModelAuthor = 'google' | 'openai'
+export type Model = 'gpt-3.5-turbo-16k' | 'gpt-3.5-turbo' | 'gpt-4' | 'gpt-4-turbo-preview' | 'gemini-1.0-pro' | 'gemini-1.5-pro-latest'
+export type Role = 'system' | 'user' | 'assistant' | 'guidance'
+export type MessagePart =
   | { text: string }
   | { imageURL: string, imageDetail?}
   | { imageB64Url: string,  imageDetail?}
   | { data: Buffer, mimeType?: string, imageDetail? }
-type Message =
+export type Message =
   | { role: Role, text: string }
   | { role: Role, parts: MessagePart[] }
-type ChunkCb = ({ n: number, textDelta: string, parts: MessagePart, done: boolean }) => void
-type FnCalls = Record<number, {
-  id: number,
-  name: string,
-  args: Record<string, any>
-}>
-type CompletionResponse = { type: 'text' | 'function', parts: MessagePart[], text?: string, fnCalls?: FnCalls }
+export type ChunkCb = ({ n: number, textDelta: string, parts: MessagePart, done: boolean }) => void
+
+export type FnCall = { id?: number, name: string, args: Record<string, any> }
+// TODO: Turn FnCalls from Record<number, FnCall> to FnCall[] (breaking)
+export type FnCalls = Record<number, FnCall>
+export type CompletionResponse = { type: 'text' | 'function', parts: MessagePart[], text?: string, fnCalls?: FnCalls }
 
 declare module 'langxlang' {
   type CompletionOptions = {
@@ -141,7 +138,7 @@ declare module 'langxlang' {
       author: ModelAuthor | string,
       model: Model | string,
       systemPrompt?: string,
-      options: { generationOptions: CompletionOptions, functions?: Functions }
+      options?: { generationOptions: CompletionOptions, functions?: Functions }
     )
     // constructor(completionService: SomeCompletionService, author: ModelAuthor | string, model: Model | string, systemPrompt?: string, options?: { functions?: Functions<T>, generationOptions?: CompletionOptions })
     // Send a message to the LLM and receive a response as return value. The chunkCallback
@@ -158,7 +155,7 @@ declare module 'langxlang' {
       messages: Message[],
       chunkCallback?: ChunkCb,
       generationOptions?: CompletionOptions & { endOnFnCall?: boolean }
-    ): Promise<{ parts: MessagePart[], text?: string, calledFunctions: FnCalls[] }>
+    ): Promise<{ parts: MessagePart[], text?: string, calledFunctions: FnCall[] }>
   }
 
   // ============ TOOLS ============

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -13,7 +13,7 @@ export type ChunkCb = ({ n: number, textDelta: string, parts: MessagePart, done:
 
 export type FnCall = { id?: number, name: string, args: Record<string, any> }
 // TODO: Turn FnCalls from Record<number, FnCall> to FnCall[] (breaking)
-export type FnCalls = Record<number, FnCall>
+export type FnCalls = FnCall[]
 export type CompletionResponse = { type: 'text' | 'function', parts: MessagePart[], text?: string, fnCalls?: FnCalls }
 
 declare module 'langxlang' {
@@ -155,7 +155,7 @@ declare module 'langxlang' {
       messages: Message[],
       chunkCallback?: ChunkCb,
       generationOptions?: CompletionOptions & { endOnFnCall?: boolean }
-    ): Promise<{ parts: MessagePart[], text?: string, calledFunctions: FnCall[] }>
+    ): Promise<{ parts: MessagePart[], text?: string, calledFunctions: FnCall[][], endReason: 'text' | 'function' }>
   }
 
   // ============ TOOLS ============

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -128,7 +128,7 @@ declare module 'langxlang' {
   }
 
   // The functions that can be used in the user prompt.
-  type ModelFn = (input: any) => any & { description: string, parameters?: Record<string, { type: any, description?: string, required?: boolean }> }
+  type ModelFn = ((input: any) => any) & { description: string, parameters?: Record<string, { type: any, description?: string, required?: boolean }> }
   type Functions = Record<string, ModelFn>
 
   class ChatSession/*<T extends any[]>*/ {


### PR DESCRIPTION
Breaking: fnCalls is now an array instead of an array-like object

Add .requestUsage to all returned completion choices in `.requestCompletion` and `.requestChatCompletion`. In ChatSession, it's the `.usage` property.

Add CompletionService audio functions
- requestTranscription
- requestSpeechSynthesis

Add `setAndSendMessages`, `setFunctions` methods to ChatSession to set custom history and functions after initializing ChatSession object